### PR TITLE
Downgrade Java to 17 version

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Install Java
       uses: actions/setup-java@v3
       with:
-        java-version: "18"
+        java-version: "17"
         distribution: "temurin"
     - name: Run unit tests
       run: ./gradlew test
@@ -26,7 +26,7 @@ jobs:
     - name: Install Java
       uses: actions/setup-java@v3
       with:
-        java-version: "18"
+        java-version: "17"
         distribution: "temurin"
     - name: Run lint check
       run: ./gradlew ktlintCheck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ While filling the form, add all relevant information, including:
 
 Contributions via pull requests are much appreciated.
 
-Dependency: You should have JDK 18 installed.
+Dependency: You should have JDK 17 installed.
 
 Before submitting a pull request, please ensure that:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ There are 2 ways to provide the API credentials in order to communicate with Dat
 
 ## Getting started
 
-Start using our library  in a gradle project by following the steps below:
+This library is compiled with JDK 17. Your project should be on JDK 17+ in order to use it. 
+
+Start using the library in a gradle project by following the steps below:
 
 1. In the gradle project, add a new source set and Gradle task to run test generation in `build.gradle.kts` file.
 ```kotlin


### PR DESCRIPTION
Subject: Downgrade Java to 17 version

Problem: JDK 18 is not a Long Time Support version, so there might be compatibility issues when using it in the projects with JDK 17.

Solution: Downgrade Java from 18 to 17 version.