### PR TITLE
Prepare to release 1.1.0 version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,11 @@ updates:
     schedule:
       interval: weekly
       time: "09:00"
-      timezone: "CET"
+      timezone: "Europe/Berlin"
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: weekly
       time: "09:00"
-      timezone: "CET"
+      timezone: "Europe/Berlin"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,16 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
+
+### Bug fixes
+
+### Dependencies
+
+## [1.1.0] - 2023-02-21
+### New features & improvements
 - Improve the configuration setup code ([#36](https://github.com/personio/datadog-synthetic-test-support/pull/36))
 - Upgrade Java to 17 version ([#12](https://github.com/personio/datadog-synthetic-test-support/pull/12))
 - Get configurations from yaml file ([16cbb0f](https://github.com/personio/datadog-synthetic-test-support/commit/16cbb0fb40d24e98d1fb1d20da5786004cdeb2bf))
-
-### Bug fixes
 
 ### Dependencies
 - Update datadog-api-client dependency from 2.2.0 to 2.9.0 ([#20](https://github.com/personio/datadog-synthetic-test-support/pull/20), [#48](https://github.com/personio/datadog-synthetic-test-support/pull/48), [#67](https://github.com/personio/datadog-synthetic-test-support/pull/67), [#71](https://github.com/personio/datadog-synthetic-test-support/pull/71))


### PR DESCRIPTION
Problem:
- Dependabot timezone is incorrectly set.
- In order to prepare to the new release Changelog file needs to contain new release section. 

Solution:
- Adjust timezone in dependabot file.
- Add a new release section 1.1.0 to the Changelog