### PR TITLE
Update dependabot schedule interval

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,13 +3,13 @@ updates:
   - package-ecosystem: gradle
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "monthly"
       time: "09:00"
       timezone: "Europe/Berlin"
     open-pull-requests-limit: 10
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "monthly"
       time: "09:00"
       timezone: "Europe/Berlin"


### PR DESCRIPTION
Problem: weekly dependabot updates are too often.
Solution: change dependabot schedule interval to monthly.