### PR TITLE
Fix pom attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Synthetic Test Support
 
-This library provides a programmatic way to manage Datadog synthetic browser tests. This library contains all the necessary functions that are required to manage the synthetic browser tests with different steps and configurations.
+Datadog Synthetic test Support library provides a programmatic way to manage Datadog synthetic browser tests. The library contains all the necessary functions that are required to manage the synthetic browser tests with different steps and configurations.
 
 [![License](https://img.shields.io/badge/License-MIT-brightgreen)](https://github.com/personio/datadog-synthetic-test-support/blob/master/LICENSE)
 [![Version](https://img.shields.io/github/v/release/personio/datadog-synthetic-test-support)](https://github.com/personio/datadog-synthetic-test-support/releases)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,11 +124,11 @@ publishing {
                     developerConnection.set("scm:git:ssh://github.com:personio/datadog-synthetic-test-support.git")
                 }
                 issueManagement {
-                    description.set("GitHub Issues")
+                    system.set("GitHub Issues")
                     url.set("https://github.com/personio/datadog-synthetic-test-support/issues")
                 }
                 ciManagement {
-                    description.set("GitHub Actions")
+                    system.set("GitHub Actions")
                     url.set("https://github.com/personio/datadog-synthetic-test-support/actions")
                 }
             }


### PR DESCRIPTION
**Problem**: Issue and CI management doesn't have description attribute. Because of this project description on Maven Central is taken from CI management description attribute.
**Solution**: Use system attribute in Issue and CI management sections in pom.