### PR TITLE
Update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,22 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
-- Add advanced scheduling option to the test configuration
 
 ### Bug fixes
+
+### Dependencies
+
+## [1.2.0] - 2023-06-21
+### New features & improvements
+- Add advanced scheduling option to the test configuration ([#101](https://github.com/personio/datadog-synthetic-test-support/pull/101))
 
 ### Dependencies
 - Update datadog-api-client dependency from 2.9.0 to 2.12.0 ([#80](https://github.com/personio/datadog-synthetic-test-support/pull/80), [#89](https://github.com/personio/datadog-synthetic-test-support/pull/89), [#98](https://github.com/personio/datadog-synthetic-test-support/pull/98))
 - Update jackson-dataformat-yaml dependency from 2.15.0 to 2.15.2 ([#96](https://github.com/personio/datadog-synthetic-test-support/pull/96))
 - Update jackson-module-kotlin dependency from 2.15.0 to 2.15.2 ([#96](https://github.com/personio/datadog-synthetic-test-support/pull/96))
-- Update kotlin-stdlib dependency from 1.8.10 to 1.8.21 ([#83](https://github.com/personio/datadog-synthetic-test-support/pull/83), [#91](https://github.com/personio/datadog-synthetic-test-support/pull/91))
+- Update kotlin-stdlib dependency from 1.8.10 to 1.8.22 ([#83](https://github.com/personio/datadog-synthetic-test-support/pull/83), [#91](https://github.com/personio/datadog-synthetic-test-support/pull/91), [#102](https://github.com/personio/datadog-synthetic-test-support/pull/102))
 - Update kotlinx-serialization-json dependency from 1.4.1 to 1.5.1 ([#78](https://github.com/personio/datadog-synthetic-test-support/pull/78), [#99](https://github.com/personio/datadog-synthetic-test-support/pull/99))
-- Update secretsmanager dependency from 2.20.8 to 2.20.76 ([#77](https://github.com/personio/datadog-synthetic-test-support/pull/77), [#81](https://github.com/personio/datadog-synthetic-test-support/pull/81), [#94](https://github.com/personio/datadog-synthetic-test-support/pull/94), [#95](https://github.com/personio/datadog-synthetic-test-support/pull/95))
+- Update secretsmanager dependency from 2.20.8 to 2.20.88 ([#77](https://github.com/personio/datadog-synthetic-test-support/pull/77), [#81](https://github.com/personio/datadog-synthetic-test-support/pull/81), [#94](https://github.com/personio/datadog-synthetic-test-support/pull/94), [#95](https://github.com/personio/datadog-synthetic-test-support/pull/95), [#102](https://github.com/personio/datadog-synthetic-test-support/pull/102))
 
 ## [1.1.0] - 2023-02-21
 ### New features & improvements

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,8 +1,8 @@
 plugins {
-    val kotlinVersion = "1.8.10"
+    val kotlinVersion = "1.8.22"
     id("org.jetbrains.kotlin.jvm") version kotlinVersion
-    id("org.jetbrains.dokka") version kotlinVersion
-    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
+    id("org.jetbrains.dokka") version "1.8.20"
+    id("org.jlleitschuh.gradle.ktlint") version "11.4.0"
     kotlin("plugin.serialization") version kotlinVersion
     `maven-publish`
     jacoco
@@ -31,8 +31,8 @@ val e2eTest =
     }
 
 dependencies {
-    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.21")
-    val awsSdkVersion = "2.20.76"
+    implementation("org.jetbrains.kotlin:kotlin-stdlib:1.8.22")
+    val awsSdkVersion = "2.20.88"
     val jacksonVersion = "2.15.2"
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")


### PR DESCRIPTION
Problem: Dependencies are outdated when a new release is planned.
Solution: Update dependencies to the latest versions before a new release