### PR TITLE
Add Multi-Step API Synthetic Test support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Dependencies: updates of dependency versions
 
 ## [Unreleased] - yyyy-mm-dd
+### New features & improvements
+- Add support for Multi-Step API Synthetic Tests
 
 ### Breaking changes
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Start using the library in a gradle project by following the steps below:
 5. Implement your synthetic mutli-step API tests, for example like this:
 ```kotlin
     fun `add a multi-step API synthetic test`() {
-    syntheticBrowserTest("Test Login to the app") {
+    syntheticMultiStepApiTest("Test Login to the app") {
         tags("env:qa")
         baseUrl(URL("https://synthetic-test.personio.de"))
         publicLocations(Location.FRANKFURT_AWS)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     testRuntimeOnly("software.amazon.awssdk:sts:$awsSdkVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.10.0")
     testImplementation("org.junit.jupiter:junit-jupiter-engine:5.10.0")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:5.10.0")
     testImplementation("org.mockito:mockito-inline:5.2.0")
     testImplementation("org.mockito.kotlin:mockito-kotlin:5.1.0")
     testImplementation("io.kotest:kotest-runner-junit5-jvm:5.6.2")

--- a/src/main/kotlin/com/personio/synthetics/builder/AssertionsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/AssertionsBuilder.kt
@@ -1,0 +1,97 @@
+package com.personio.synthetics.builder
+
+import com.datadog.api.client.v1.model.SyntheticsAssertion
+import com.datadog.api.client.v1.model.SyntheticsAssertionJSONPathOperator
+import com.datadog.api.client.v1.model.SyntheticsAssertionJSONPathTarget
+import com.datadog.api.client.v1.model.SyntheticsAssertionJSONPathTargetTarget
+import com.datadog.api.client.v1.model.SyntheticsAssertionOperator
+import com.datadog.api.client.v1.model.SyntheticsAssertionTarget
+import com.datadog.api.client.v1.model.SyntheticsAssertionType
+
+class AssertionsBuilder {
+    private val assertions = mutableListOf<SyntheticsAssertion>()
+
+    fun build(): List<SyntheticsAssertion> {
+        return assertions
+    }
+
+    /**
+     * Asserts the response status code
+     * @param code Status code
+     */
+    fun statusCode(code: Int) {
+        target(
+            SyntheticsAssertionType.STATUS_CODE,
+            SyntheticsAssertionOperator.IS,
+            code
+        )
+    }
+
+    /**
+     * Asserts that the response header contains the given value
+     * @param name Header name
+     * @param value Value to look for
+     */
+    fun headerContains(name: String, value: String) {
+        assertions.add(
+            SyntheticsAssertion(
+                SyntheticsAssertionTarget()
+                    .property(name)
+                    .operator(SyntheticsAssertionOperator.CONTAINS)
+                    .type(SyntheticsAssertionType.HEADER)
+                    .target(value)
+            )
+        )
+    }
+
+    /**
+     * Asserts that the value at the JSON path in the response body contains the given value
+     * @param jsonPath JSON path
+     * @param targetValue Value to look for
+     */
+    fun bodyContainsJsonPath(jsonPath: String, targetValue: Any) {
+        assertions.add(
+            SyntheticsAssertion(
+                SyntheticsAssertionJSONPathTarget()
+                    .operator(SyntheticsAssertionJSONPathOperator.VALIDATES_JSON_PATH)
+                    .type(SyntheticsAssertionType.BODY)
+                    .target(
+                        SyntheticsAssertionJSONPathTargetTarget()
+                            .jsonPath(jsonPath)
+                            .operator("contains")
+                            .targetValue(targetValue)
+                    )
+            )
+        )
+    }
+
+    /**
+     * Asserts that the response body contains the given value
+     * @param value Value to look for
+     */
+    fun bodyContains(value: Any) {
+        target(
+            SyntheticsAssertionType.BODY,
+            SyntheticsAssertionOperator.CONTAINS,
+            value
+        )
+    }
+
+    /**
+     * Adds an assertion for a given assertion type, operator and target
+     * @param type Assertion type
+     * @param operator Assertion operator
+     * @param target Target
+     */
+    private fun target(type: SyntheticsAssertionType, operator: SyntheticsAssertionOperator, target: Any) {
+        assertions.add(
+            SyntheticsAssertion(
+                SyntheticsAssertionTarget(
+                    operator,
+                    target,
+                    type
+                )
+            )
+        )
+    }
+}

--- a/src/main/kotlin/com/personio/synthetics/builder/RequestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/RequestBuilder.kt
@@ -1,0 +1,79 @@
+package com.personio.synthetics.builder
+
+import com.datadog.api.client.v1.model.SyntheticsTestRequest
+import com.datadog.api.client.v1.model.SyntheticsTestRequestBodyType
+
+class RequestBuilder {
+    private var url = ""
+    private var method = RequestMethod.GET
+    private var bodyType: SyntheticsTestRequestBodyType = SyntheticsTestRequestBodyType.APPLICATION_JSON
+    private var body = ""
+    private var followRedirects = false
+    private var headers: Map<String, String> = mapOf()
+
+    fun build(): SyntheticsTestRequest {
+        return SyntheticsTestRequest()
+            .url(url)
+            .method(method.name)
+            .bodyType(bodyType)
+            .body(body)
+            .followRedirects(followRedirects)
+            .headers(headers)
+    }
+
+    /**
+     * Appends the cookie header
+     * @param value Cookie value
+     */
+    fun cookies(value: String) {
+        headers += mapOf("Cookie" to value)
+    }
+
+    /**
+     * Sets the request URL
+     * @param value URL
+     */
+    fun url(value: String) {
+        url = value
+    }
+
+    /**
+     * Sets the request method
+     * @param value Request method
+     */
+    fun method(value: RequestMethod) {
+        method = value
+    }
+
+    /**
+     * Sets the request body type
+     * @param value Request body type
+     */
+    fun bodyType(value: SyntheticsTestRequestBodyType) {
+        bodyType = value
+    }
+
+    /**
+     * Sets the request body
+     * @param value Request body
+     */
+    fun body(value: String) {
+        body = value
+    }
+
+    /**
+     * Sets the need to follow any redirects
+     * @param value Whether Datadog should follow any redirects
+     */
+    fun followRedirects(value: Boolean) {
+        followRedirects = value
+    }
+
+    /**
+     * Appends the request headers
+     * @param headers Headers
+     */
+    fun headers(headers: Map<String, String>) {
+        this.headers += headers
+    }
+}

--- a/src/main/kotlin/com/personio/synthetics/builder/RequestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/RequestBuilder.kt
@@ -10,6 +10,7 @@ class RequestBuilder {
     private var body = ""
     private var followRedirects = false
     private var headers: Map<String, String> = mapOf()
+    private var ignoreServerCertificateError = false
 
     fun build(): SyntheticsTestRequest {
         return SyntheticsTestRequest()
@@ -18,6 +19,7 @@ class RequestBuilder {
             .bodyType(bodyType)
             .body(body)
             .followRedirects(followRedirects)
+            .allowInsecure(ignoreServerCertificateError)
             .headers(headers)
     }
 
@@ -67,6 +69,14 @@ class RequestBuilder {
      */
     fun followRedirects(value: Boolean) {
         followRedirects = value
+    }
+
+    /**
+     * Sets the need to ignore server certificate error
+     * @param value Whether Datadog should ignore service certificate error during request
+     */
+    fun ignoreServerCertificateError(value: Boolean) {
+        ignoreServerCertificateError = value
     }
 
     /**

--- a/src/main/kotlin/com/personio/synthetics/builder/RequestMethod.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/RequestMethod.kt
@@ -1,0 +1,8 @@
+package com.personio.synthetics.builder
+
+/**
+ * An enum representing HTTP methods
+ */
+enum class RequestMethod {
+    GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE;
+}

--- a/src/main/kotlin/com/personio/synthetics/builder/RequestMethod.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/RequestMethod.kt
@@ -4,5 +4,5 @@ package com.personio.synthetics.builder
  * An enum representing HTTP methods
  */
 enum class RequestMethod {
-    GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS, TRACE;
+    GET, HEAD, POST, PUT, PATCH, DELETE, OPTIONS;
 }

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilder.kt
@@ -1,0 +1,80 @@
+package com.personio.synthetics.builder
+
+import com.datadog.api.client.v1.model.SyntheticsAPIStep
+import com.datadog.api.client.v1.model.SyntheticsAPITest
+import com.datadog.api.client.v1.model.SyntheticsAPITestConfig
+import com.datadog.api.client.v1.model.SyntheticsAPITestType
+import com.datadog.api.client.v1.model.SyntheticsConfigVariable
+import com.datadog.api.client.v1.model.SyntheticsConfigVariableType
+import com.datadog.api.client.v1.model.SyntheticsTestDetailsSubType
+import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
+import com.personio.synthetics.builder.api.StepsBuilder
+import com.personio.synthetics.client.SyntheticsApiClient
+import com.personio.synthetics.config.Defaults
+
+/**
+ * A builder for creating multi-step SyntheticAPITest instances
+ */
+class SyntheticMultiStepApiTestBuilder(
+    override val name: String,
+    defaults: Defaults,
+    apiClient: SyntheticsApiClient
+) : SyntheticTestBuilder(name, defaults, apiClient) {
+    private val config = SyntheticsAPITestConfig()
+
+    /**
+     * Builds a synthetic API test
+     * @return SyntheticsAPITest object that contains an API test
+     */
+    fun build(): SyntheticsAPITest =
+        SyntheticsAPITest(
+            config,
+            parameters.locations,
+            parameters.message,
+            name,
+            options,
+            SyntheticsAPITestType.API
+        )
+            .tags(parameters.tags)
+            .status(SyntheticsTestPauseStatus.PAUSED)
+            .subtype(SyntheticsTestDetailsSubType.MULTI)
+
+    /**
+     * Specifies API steps for a test using a DSL
+     * @param stepsBuilder A builder to use for building synthetic API steps
+     * @param init A function to apply to the specified builder instance
+     */
+    fun steps(stepsBuilder: StepsBuilder = StepsBuilder(), init: StepsBuilder.() -> Unit) {
+        config.steps(stepsBuilder.apply(init).build())
+    }
+
+    /**
+     * Specifies API steps for a test
+     * @param steps A list of synthetic API steps
+     */
+    fun steps(steps: List<SyntheticsAPIStep>) {
+        config.steps(steps)
+    }
+
+    override fun addLocalVariable(name: String, pattern: String) {
+        config.addConfigVariablesItem(
+            SyntheticsConfigVariable()
+                .name(name.uppercase())
+                .type(SyntheticsConfigVariableType.TEXT)
+                .pattern(pattern)
+                .example("")
+        )
+    }
+
+    override fun useGlobalVariable(name: String) {
+        val variableName = name.uppercase()
+        val variableId = getGlobalVariableId(variableName)
+        checkNotNull(variableId) { "The global variable $name to be used in the test doesn't exist in DataDog." }
+        config.addConfigVariablesItem(
+            SyntheticsConfigVariable()
+                .name(variableName)
+                .id(variableId)
+                .type(SyntheticsConfigVariableType.GLOBAL)
+        )
+    }
+}

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
@@ -1,0 +1,320 @@
+package com.personio.synthetics.builder
+
+import com.datadog.api.client.v1.model.SyntheticsDeviceID
+import com.datadog.api.client.v1.model.SyntheticsTestOptions
+import com.datadog.api.client.v1.model.SyntheticsTestOptionsMonitorOptions
+import com.datadog.api.client.v1.model.SyntheticsTestOptionsRetry
+import com.datadog.api.client.v1.model.SyntheticsTestOptionsScheduling
+import com.datadog.api.client.v1.model.SyntheticsTestOptionsSchedulingTimeframe
+import com.personio.synthetics.client.SyntheticsApiClient
+import com.personio.synthetics.config.Defaults
+import com.personio.synthetics.domain.SyntheticTestParameters
+import com.personio.synthetics.model.config.Location
+import com.personio.synthetics.model.config.MonitorPriority
+import com.personio.synthetics.model.config.RenotifyInterval
+import com.personio.synthetics.model.config.Timeframe
+import java.time.ZoneId
+import java.time.temporal.ChronoUnit
+import kotlin.math.absoluteValue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+
+/**
+ * An abstract class that wraps common methods for Synthetic Browser and API tests
+ */
+abstract class SyntheticTestBuilder(
+    open val name: String,
+    defaults: Defaults,
+    private val apiClient: SyntheticsApiClient
+) {
+    protected var parameters: SyntheticTestParameters
+    protected var options: SyntheticsTestOptions
+    protected var locations: List<String> = defaults.runLocations
+
+    init {
+        parameters = SyntheticTestParameters(
+            message = "",
+            locations = defaults.runLocations,
+            tags = mutableListOf()
+        )
+
+        options = SyntheticsTestOptions()
+            .addDeviceIdsItem(SyntheticsDeviceID.CHROME_LAPTOP_LARGE)
+            .tickEvery(defaults.testFrequency / 1000)
+            .minFailureDuration(defaults.minFailureDuration / 1000)
+            .minLocationFailed(defaults.minLocationFailed)
+            .retry(
+                SyntheticsTestOptionsRetry()
+                    .count(defaults.retryCount)
+                    .interval(defaults.retryInterval)
+            )
+            .monitorOptions(
+                SyntheticsTestOptionsMonitorOptions()
+            )
+    }
+
+    /**
+     * Sets the monitor name for the synthetic test
+     * @param monitorName The monitor name of the test
+     */
+    fun monitorName(monitorName: String) {
+        options.monitorName = monitorName
+    }
+
+    /**
+     * Configures the alert message to be sent when the test fails
+     * @param failureMessage The message that needs to be sent to the configured alert medium upon test failure
+     * @param alertMedium Specify one or more alert mediums. It can be Slack channels, email addresses and so on
+     * For Slack channels, the channel name should be prefixed with "@slack-"
+     * For email address, the email should be prefixed with "@"
+     * Example: Slack channel -> @slack-test_slack_channel
+     * Email -> @firstName.lastName@domain.com
+     */
+    fun alertMessage(failureMessage: String, vararg alertMedium: String) {
+        parameters.message += "${alertMedium.joinToString(" ")} {{#is_alert}} $failureMessage {{/is_alert}} "
+    }
+
+    /**
+     * Configures the recovery message when the test recovers
+     * @param recoveryMessage The message that needs to be sent upon recovery from a failure
+     */
+    fun recoveryMessage(recoveryMessage: String) {
+        parameters.message += " {{#is_recovery}} $recoveryMessage {{/is_recovery}} "
+    }
+
+    /**
+     * Sets the tags for the synthetic test
+     * @param tags List of tags
+     */
+    fun tags(vararg tags: String) {
+        parameters.tags.addAll(tags)
+    }
+
+    /**
+     * Sets the locations for the synthetic test
+     * @param locations List of locations
+     */
+    fun publicLocations(vararg locations: Location) {
+        parameters.locations = locations.map { it.value }
+    }
+
+    /**
+     * Sets the test frequency for the synthetic test
+     * @param frequency The frequency of the test
+     * Allowed test frequency is between 30 seconds and 7 days
+     */
+    fun testFrequency(frequency: Duration) {
+        require(frequency in 30.seconds..7.days) {
+            "Frequency should be between 30 seconds and 1 week."
+        }
+        options.tickEvery = frequency.inWholeSeconds
+    }
+
+    /**
+     * Sets the advanced scheduling configuration for the synthetic test
+     * @param timeframe Time range and days when the test should be scheduled to run
+     * - from/to time -> pass LocalTime data type values where From value is earlier than To value
+     * - days -> pass comma separated DayOfWeek data type values
+     * @param timezone Timezone where the tests should be scheduled to run
+     * Pass ZoneId data type value, e.g. 'ZoneId.of("Europe/Berlin")'
+     * Offset value is set as the local timezone of the machine where the test creation runs, if the value is not explicitly set
+     */
+    fun advancedScheduling(timeframe: Timeframe, timezone: ZoneId = ZoneId.systemDefault()) {
+        options.scheduling = SyntheticsTestOptionsScheduling()
+        options.scheduling.timeframes = timeframe.days.map {
+            SyntheticsTestOptionsSchedulingTimeframe().apply {
+                from = timeframe.from.truncatedTo(ChronoUnit.MINUTES).toString()
+                to = timeframe.to.truncatedTo(ChronoUnit.MINUTES).toString()
+                day = it.value
+            }
+        }
+        options.scheduling.timezone = timezone.toString()
+    }
+
+    /**
+     * Sets the retry count and interval for the synthetic test
+     * @param retryCount The retry count for the test
+     * Allowed retry count is between 0 and 2
+     * @param retryInterval The retry interval for the test
+     * Allowed retry interval is between 0 and 15 minutes
+     */
+    fun retry(retryCount: Long, retryInterval: Duration) {
+        require(retryCount in 0..2) {
+            "Retry count should be between 0 and 2."
+        }
+        require(retryInterval in 0.milliseconds..15.minutes) {
+            "Retry interval should be between 0 and 15 minutes."
+        }
+        options.retry.count = retryCount
+        options.retry.interval = retryInterval.inWholeMilliseconds.toDouble()
+    }
+
+    /**
+     * Sets the minimum failure duration for the synthetic test
+     * @param minFailureDuration The minimum failure duration of the test
+     * Allowed minimum failure duration is between 0 and 120 minutes
+     */
+    fun minFailureDuration(minFailureDuration: Duration) {
+        require(minFailureDuration in 0.minutes..120.minutes) {
+            "Minimum failure duration should be between 0 and 120 minutes."
+        }
+        options.minFailureDuration = minFailureDuration.inWholeSeconds
+    }
+
+    /**
+     * Sets the minimum location failed for the synthetic test
+     * @param minLocationFailed The minimum number of locations in which the test has failed to trigger the alert
+     * Allowed minimum location failed is between 1 and the number of locations where the test is configured to run
+     */
+    fun minLocationFailed(minLocationFailed: Long) {
+        require(minLocationFailed in 1..locations.count()) {
+            "Minimum location failed should be between 1 and the number of locations where the test is configured to run: ${locations.count()}."
+        }
+        options.minLocationFailed = minLocationFailed
+    }
+
+    /**
+     * Sets the renotify interval for the synthetic test
+     * @param renotifyInterval The renotify interval for the test derived from RenotifyInterval enum class
+     */
+    fun renotifyInterval(renotifyInterval: RenotifyInterval) {
+        options.monitorOptions!!.renotifyInterval = renotifyInterval.valueInMinutes
+    }
+
+    /**
+     * Sets the monitor priority for the synthetic test
+     * @param monitorPriority The monitor priority of the test
+     * Allowed monitor priority is one of [1, 2, 3, 4, 5]
+     */
+    fun monitorPriority(monitorPriorities: MonitorPriority) {
+        options.monitorPriority = monitorPriorities.priorityValue
+    }
+
+    /**
+     * Creates a local variable with the supplied string as a value
+     * @param name Name of the variable. The name would be converted to upper case letters
+     * @param value Supply the text to be set for the variable
+     */
+    fun textVariable(name: String, value: String) = apply {
+        addLocalVariable(name, value)
+    }
+
+    /**
+     * Creates a local variable with the numeric pattern
+     * The value of the variable will be a generated random numeric string with n digits
+     * @param name Name of the variable. The name would be converted to upper case letters
+     * @param characterLength Length of the random numeric value that's generated
+     * @param prefix String to be appended before the pattern
+     * @param suffix String to be appended after the pattern
+     */
+    fun numericPatternVariable(name: String, characterLength: Int, prefix: String = "", suffix: String = "") {
+        addLocalVariable(name, "$prefix{{ numeric($characterLength) }}$suffix")
+    }
+
+    /**
+     * Creates a local variable with the alphabetic pattern
+     * The value of the variable will be a generated random alphabetic string with n characters
+     * @param name Name of the variable. The name would be converted to upper case letters
+     * @param characterLength Length of the random alphabetic value that's generated
+     * @param prefix String to be appended before the pattern
+     * @param suffix String to be appended after the pattern
+     */
+    fun alphabeticPatternVariable(name: String, characterLength: Int, prefix: String = "", suffix: String = "") {
+        addLocalVariable(name, "$prefix{{ alphabetic($characterLength) }}$suffix")
+    }
+
+    /**
+     * Creates a local variable with the alphanumeric pattern
+     * The value of the variable will be a generated random alphanumeric string with n characters
+     * @param name Name of the variable. The name would be converted to upper case letters
+     * @param characterLength Length of the random alphanumeric value that's generated
+     * @param prefix String to be appended before the pattern
+     * @param suffix String to be appended after the pattern
+     */
+    fun alphanumericPatternVariable(name: String, characterLength: Int, prefix: String = "", suffix: String = "") {
+        addLocalVariable(name, "$prefix{{ alphanumeric($characterLength) }}$suffix")
+    }
+
+    /**
+     * Creates a local variable with the date pattern
+     * The value of the variable will be a generated date in UTC in one of the accepted formats with a value corresponding to the date the test is initiated at +/- nunit
+     * @param name Name of the variable. The name would be converted to upper case letters
+     * @param duration The duration (+ or -) to be added to or subtracted from the time by which the test is run to generate the date
+     * @param format Pass one of the accepted format in which the date needs to be generated
+     * @param prefix String to be appended before the pattern
+     * @param suffix String to be appended after the pattern
+     * The accepted formats are according to https://date-fns.org/v1.29.0/docs/format
+     */
+    fun datePatternVariable(name: String, duration: Duration, format: String, prefix: String = "", suffix: String = "") {
+        val (scaledValue, unit) = checkNotNull(getScaledDate(duration)) {
+            "The passed duration should be less than 10_000_000 days for the date pattern variable $name."
+        }
+        addLocalVariable(name, "$prefix{{ date($scaledValue$unit, $format) }}$suffix")
+    }
+
+    /**
+     * Creates a local variable with the timestamp pattern
+     * The value of the variable will be a generated timestamp in one of the accepted formats with a value corresponding to the timestamp the test is initiated at +/- n unit.
+     * @param name Name of the variable. The name would be converted to upper case letters
+     * @param duration The duration (+ or -) to be added to or subtracted from the time by which the test is run to generate the date
+     * @param prefix String to be appended before the pattern
+     * @param suffix String to be appended after the pattern
+     */
+    fun timestampPatternVariable(name: String, duration: Duration, prefix: String = "", suffix: String = "") {
+        val (scaledValue, unit) = checkNotNull(getScaledTimestamp(duration)) {
+            "The passed duration should be less than 1_000_000_000 seconds for the timestamp pattern variable $name."
+        }
+        addLocalVariable(name, "$prefix{{ timestamp($scaledValue, $unit) }}$suffix")
+    }
+
+    /**
+     * Creates a local variable with the UUID pattern
+     * @param name Name of the variable. The name would be converted to upper case letters
+     */
+    fun uuidVariable(name: String) {
+        addLocalVariable(name, "{{ uuid }}")
+    }
+
+    private fun getScaledDate(value: Duration): Pair<Long, String>? =
+        value.getScaledValue(
+            sequenceOf(DurationUnit.MILLISECONDS, DurationUnit.SECONDS, DurationUnit.MINUTES, DurationUnit.HOURS, DurationUnit.DAYS),
+            10_000_000
+        )
+
+    private fun getScaledTimestamp(value: Duration): Pair<Long, String>? =
+        value.getScaledValue(
+            sequenceOf(DurationUnit.MILLISECONDS, DurationUnit.SECONDS),
+            1_000_000_000
+        )
+
+    private fun Duration.getScaledValue(sequence: Sequence<DurationUnit>, limit: Long): Pair<Long, String>? =
+        sequence
+            .map { unit -> this.toLong(unit) to unit.toDatadogDurationUnit() }
+            .firstOrNull { (scaled, _) -> scaled.absoluteValue < limit }
+
+    private fun DurationUnit.toDatadogDurationUnit(): String {
+        return when (this) {
+            DurationUnit.MILLISECONDS -> "ms"
+            DurationUnit.SECONDS -> "s"
+            DurationUnit.MINUTES -> "m"
+            DurationUnit.HOURS -> "h"
+            DurationUnit.DAYS -> "d"
+            else -> throw IllegalArgumentException("The given duration unit is not supported.")
+        }
+    }
+
+    protected fun getGlobalVariableId(variableName: String) =
+        apiClient.listGlobalVariables()
+            .variables
+            .orEmpty()
+            .filterNotNull()
+            .find { it.name.equals(variableName) }
+            ?.id
+
+    protected abstract fun addLocalVariable(name: String, pattern: String)
+    abstract fun useGlobalVariable(name: String)
+}

--- a/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
@@ -1,0 +1,86 @@
+package com.personio.synthetics.builder.api
+
+import com.datadog.api.client.v1.model.SyntheticsAPIStep
+import com.datadog.api.client.v1.model.SyntheticsAPIStepSubtype
+import com.datadog.api.client.v1.model.SyntheticsAssertion
+import com.datadog.api.client.v1.model.SyntheticsParsingOptions
+import com.datadog.api.client.v1.model.SyntheticsTestRequest
+import com.personio.synthetics.builder.AssertionsBuilder
+import com.personio.synthetics.builder.RequestBuilder
+import com.personio.synthetics.builder.parsing.ParsingOptionsBuilder
+
+/**
+ * Builds a step for a multi-step API synthetic test
+ * @param name Name of the step
+ * @param requestBuilder Instance of a request builder to use to provide a request
+ * @param assertionBuilder Instance of an assertions builder to use to provide assertions
+ * @param parsingOptionsBuilder Instance of a parsing options builder to use to provide parsing options
+ */
+class StepBuilder(
+    val name: String,
+    private val requestBuilder: RequestBuilder = RequestBuilder(),
+    private val assertionBuilder: AssertionsBuilder = AssertionsBuilder(),
+    private val parsingOptionsBuilder: ParsingOptionsBuilder = ParsingOptionsBuilder()
+) {
+    var allowFailure = false
+    var isCritical = false
+
+    private val step = SyntheticsAPIStep()
+    private var request: SyntheticsTestRequest? = null
+    private var assertions = listOf<SyntheticsAssertion>()
+    private val parsingOptions = mutableListOf<SyntheticsParsingOptions>()
+
+    fun build(): SyntheticsAPIStep {
+        if (request == null) {
+            throw IllegalStateException("Request must be provided.")
+        }
+
+        if (allowFailure) {
+            step.isCritical(isCritical)
+        }
+
+        if (parsingOptions.isNotEmpty()) {
+            step.extractedValues(parsingOptions)
+        }
+
+        return step
+            .request(request)
+            .allowFailure(allowFailure)
+            .name(name)
+            .assertions(assertions)
+            .subtype(SyntheticsAPIStepSubtype.HTTP)
+    }
+
+    /**
+     * Sets the HTTP request for the synthetic test
+     * @param init Configuration to be applied on the RequestBuilder
+     */
+    fun request(init: RequestBuilder.() -> Unit) {
+        request = requestBuilder.apply(init).build()
+    }
+
+    /**
+     * Sets the assertions for the synthetic test
+     * @param init Configuration to be applied on the AssertionsBuilder
+     */
+    fun assertions(init: AssertionsBuilder.() -> Unit) {
+        assertions = assertionBuilder.apply(init).build()
+    }
+
+    /**
+     * Specifies the variable extraction for the synthetic test
+     * @param variableName Name of the variable
+     * @param init Configuration to be applied on the ParsingOptionsBuilder
+     */
+    fun extract(variableName: String, init: ParsingOptionsBuilder.() -> Unit) {
+        parsingOptionsBuilder.variable(variableName)
+
+        val options = parsingOptionsBuilder
+            .apply(init)
+            .build()
+
+        if (options != null) {
+            parsingOptions.add(options)
+        }
+    }
+}

--- a/src/main/kotlin/com/personio/synthetics/builder/api/StepsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/api/StepsBuilder.kt
@@ -1,0 +1,21 @@
+package com.personio.synthetics.builder.api
+
+import com.datadog.api.client.v1.model.SyntheticsAPIStep
+
+class StepsBuilder {
+    private val steps = mutableListOf<SyntheticsAPIStep>()
+
+    fun build(): List<SyntheticsAPIStep> {
+        return steps
+    }
+
+    /**
+     * Appends a SyntheticsAPIStep
+     * @param name Step name
+     * @param stepBuilder Optional step builder
+     * @param init Configuration to be applied on the step builder
+     */
+    fun step(name: String, stepBuilder: StepBuilder = StepBuilder(name), init: StepBuilder.() -> Unit) {
+        steps += stepBuilder.apply(init).build()
+    }
+}

--- a/src/main/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilder.kt
@@ -1,0 +1,97 @@
+package com.personio.synthetics.builder.parsing
+
+import com.datadog.api.client.v1.model.SyntheticsGlobalVariableParseTestOptionsType
+import com.datadog.api.client.v1.model.SyntheticsGlobalVariableParserType
+import com.datadog.api.client.v1.model.SyntheticsParsingOptions
+import com.datadog.api.client.v1.model.SyntheticsVariableParser
+
+class ParsingOptionsBuilder {
+    private var variableName: String? = null
+    private var parsingOptions: SyntheticsParsingOptions? = null
+
+    fun build(): SyntheticsParsingOptions? {
+        checkNotNull(variableName) { "Variable name must be provided." }
+        checkNotNull(parsingOptions) { "Parsing options must be provided." }
+        parsingOptions!!.name(variableName)
+
+        return parsingOptions
+    }
+
+    /**
+     * Sets the variable
+     * @param name Name of the variable
+     */
+    fun variable(name: String) {
+        variableName = name
+    }
+
+    /**
+     * Extracts the value from the response body using JSON path
+     * @param jsonPath The JSON path to extract the value from
+     * @param secure Set to true to disallow the extracted value to be read from DataDog UI
+     * By default secure is set to false allowing the extracted value to be available for reading in Datadog UI
+     */
+    fun bodyJsonPath(jsonPath: String, secure: Boolean = false) {
+        parsingOptions = SyntheticsParsingOptions()
+            .parser(
+                SyntheticsVariableParser()
+                    .type(SyntheticsGlobalVariableParserType.JSON_PATH)
+                    .value(jsonPath)
+            )
+            .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_BODY)
+            .secure(secure)
+    }
+
+    /**
+     * Extracts the value from the response body using regular expression
+     * @param regex Regular expression
+     * @param secure Set to true to disallow the extracted value to be read from DataDog UI
+     * By default secure is set to false allowing the extracted value to be available for reading in Datadog UI
+     */
+    fun bodyRegex(regex: String, secure: Boolean = false) {
+        parsingOptions = SyntheticsParsingOptions()
+            .parser(
+                SyntheticsVariableParser()
+                    .type(SyntheticsGlobalVariableParserType.REGEX)
+                    .value(regex)
+            )
+            .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_BODY)
+            .secure(secure)
+    }
+
+    /**
+     * Extracts the value from a response header
+     * @param name Header name
+     * @param secure Set to true to disallow the extracted value to be read from DataDog UI
+     * By default secure is set to false allowing the extracted value to be available for reading in Datadog UI
+     */
+    fun header(name: String, secure: Boolean = false) {
+        parsingOptions = SyntheticsParsingOptions()
+            .field(name)
+            .parser(
+                SyntheticsVariableParser()
+                    .type(SyntheticsGlobalVariableParserType.RAW)
+            )
+            .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_HEADER)
+            .secure(secure)
+    }
+
+    /**
+     * Extracts the value from a response header using regular expression
+     * @param name Header name
+     * @param regex Regular expression
+     * @param secure Set to true to disallow the extracted value to be read from DataDog UI
+     * By default secure is set to false allowing the extracted value to be available for reading in Datadog UI
+     */
+    fun headerRegex(name: String, regex: String, secure: Boolean = false) {
+        parsingOptions = SyntheticsParsingOptions()
+            .field(name)
+            .parser(
+                SyntheticsVariableParser()
+                    .type(SyntheticsGlobalVariableParserType.REGEX)
+                    .value(regex)
+            )
+            .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_HEADER)
+            .secure(secure)
+    }
+}

--- a/src/main/kotlin/com/personio/synthetics/config/BrowserTestConfig.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/BrowserTestConfig.kt
@@ -55,9 +55,6 @@ fun BrowserTest.testFrequency(frequency: Duration) = apply {
  * @return BrowserTest object with advanced scheduling configured
  */
 fun BrowserTest.advancedScheduling(timeframes: Timeframe, timezone: ZoneId = ZoneId.systemDefault()) = apply {
-    require(timeframes.from < timeframes.to) {
-        "From time must be earlier than To time."
-    }
     options.scheduling = SyntheticsTestOptionsScheduling()
     options.scheduling.timeframes = timeframes.days.map {
         SyntheticsTestOptionsSchedulingTimeframe().apply {

--- a/src/main/kotlin/com/personio/synthetics/config/ConfigurationLoader.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/ConfigurationLoader.kt
@@ -8,17 +8,28 @@ import org.apache.commons.text.lookup.StringLookupFactory
 import java.io.File
 import java.nio.file.Files
 
-fun loadConfiguration(configurationFile: String) {
-    val stringSubstitutor = StringSubstitutor(
-        StringLookupFactory.INSTANCE.environmentVariableStringLookup()
-    ).setEnableUndefinedVariableException(true)
+fun getConfigFromFile(path: String): Configuration {
+    val stringSubstitutor =
+        StringSubstitutor(StringLookupFactory.INSTANCE.environmentVariableStringLookup())
+            .setEnableUndefinedVariableException(true)
+
     ObjectMapper(YAMLFactory()).apply {
         registerModule(kotlinModule())
-        Config.testConfig = readValue(
-            stringSubstitutor.replace(String(Files.readAllBytes(File(this::class.java.classLoader.getResource(configurationFile).file).toPath()))),
+        return readValue(
+            stringSubstitutor.replace(
+                String(
+                    Files.readAllBytes(
+                        File(this::class.java.classLoader.getResource(path)!!.file).toPath()
+                    )
+                )
+            ),
             Configuration::class.java
         )
     }
+}
+
+fun loadConfiguration(configurationFile: String) {
+    Config.testConfig = getConfigFromFile(configurationFile)
 }
 
 internal object Config {

--- a/src/main/kotlin/com/personio/synthetics/domain/SyntheticTestParameters.kt
+++ b/src/main/kotlin/com/personio/synthetics/domain/SyntheticTestParameters.kt
@@ -1,0 +1,7 @@
+package com.personio.synthetics.domain
+
+data class SyntheticTestParameters(
+    var message: String,
+    var locations: List<String>,
+    var tags: MutableList<String>
+)

--- a/src/main/kotlin/com/personio/synthetics/dsl/SyntheticTestDsl.kt
+++ b/src/main/kotlin/com/personio/synthetics/dsl/SyntheticTestDsl.kt
@@ -1,0 +1,58 @@
+package com.personio.synthetics.dsl
+
+import com.datadog.api.client.v1.model.SyntheticsAPITest
+import com.personio.synthetics.builder.SyntheticMultiStepApiTestBuilder
+import com.personio.synthetics.client.AwsSecretsManagerCredentialsProvider
+import com.personio.synthetics.client.ConfigCredentialsProvider
+import com.personio.synthetics.client.CredentialsProvider
+import com.personio.synthetics.client.SyntheticsApiClient
+import com.personio.synthetics.config.Credentials
+import com.personio.synthetics.config.Defaults
+import com.personio.synthetics.config.getConfigFromFile
+
+private fun getSyntheticsApiClientAndDefaults(): Pair<SyntheticsApiClient, Defaults> {
+    val configuration = getConfigFromFile("configuration.yaml")
+
+    return SyntheticsApiClient(
+        credentialsProvider = getCredentialsProvider(configuration.credentials),
+        apiHost = configuration.datadogApiHost
+    ) to configuration.defaults
+}
+
+fun syntheticMultiStepApiTest(name: String, init: SyntheticMultiStepApiTestBuilder.() -> Unit): SyntheticsAPITest {
+    check(name.isNotBlank()) {
+        "The test's name must not be empty."
+    }
+
+    val (client, defaults) = getSyntheticsApiClientAndDefaults()
+
+    val test = SyntheticMultiStepApiTestBuilder(name, defaults, client)
+        .apply(init)
+        .build()
+
+    val testId = getTestId(client, name)
+
+    return if (testId != null) {
+        client.updateAPITest(testId, test)
+    } else {
+        client.createSyntheticsAPITest(test)
+    }
+}
+
+private fun getTestId(syntheticsApiClient: SyntheticsApiClient, name: String) =
+    syntheticsApiClient.listTests()
+        .tests
+        .orEmpty()
+        .filterNotNull()
+        .find { it.name.equals(name) }
+        ?.publicId
+
+private fun getCredentialsProvider(credentials: Credentials): CredentialsProvider {
+    return credentials.let {
+        when {
+            !it.datadogCredentialsAwsArn.isNullOrEmpty() -> AwsSecretsManagerCredentialsProvider(it)
+            !it.ddApiKey.isNullOrEmpty() && !it.ddAppKey.isNullOrEmpty() -> ConfigCredentialsProvider(it)
+            else -> throw IllegalStateException("Please set the required config values for credentials in the \"configuration.yaml\" under resources.")
+        }
+    }
+}

--- a/src/main/kotlin/com/personio/synthetics/model/config/Timeframe.kt
+++ b/src/main/kotlin/com/personio/synthetics/model/config/Timeframe.kt
@@ -3,17 +3,14 @@ package com.personio.synthetics.model.config
 import java.time.DayOfWeek
 import java.time.LocalTime
 
-class Timeframe private constructor(
-    val from: LocalTime,
-    val to: LocalTime,
-    val days: Set<DayOfWeek>
-) {
+class Timeframe private constructor(val from: LocalTime, val to: LocalTime, vararg val days: DayOfWeek) {
     companion object {
-        operator fun invoke(
-            from: LocalTime,
-            to: LocalTime,
-            day: DayOfWeek,
-            vararg moreDays: DayOfWeek
-        ) = Timeframe(from, to, setOf(day) + moreDays.toSet())
+        operator fun invoke(from: LocalTime, to: LocalTime, vararg days: DayOfWeek): Timeframe {
+            require(from < to) {
+                "From time must be earlier than To time."
+            }
+
+            return Timeframe(from, to, *days)
+        }
     }
 }

--- a/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
@@ -1,0 +1,100 @@
+package com.personio.synthetics.builder
+
+import com.datadog.api.client.v1.model.SyntheticsAssertion
+import com.datadog.api.client.v1.model.SyntheticsAssertionJSONPathOperator
+import com.datadog.api.client.v1.model.SyntheticsAssertionJSONPathTarget
+import com.datadog.api.client.v1.model.SyntheticsAssertionJSONPathTargetTarget
+import com.datadog.api.client.v1.model.SyntheticsAssertionOperator
+import com.datadog.api.client.v1.model.SyntheticsAssertionTarget
+import com.datadog.api.client.v1.model.SyntheticsAssertionType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class AssertionsBuilderTest {
+    @Test
+    fun `statusCode adds assertion that checks if the status code equals to the provided value`() {
+        val sut = AssertionsBuilder()
+        sut.statusCode(200)
+        val result = sut.build()
+
+        assertEquals(
+            SyntheticsAssertion(
+                SyntheticsAssertionTarget()
+                    .operator(SyntheticsAssertionOperator.IS)
+                    .target(200)
+                    .type(SyntheticsAssertionType.STATUS_CODE)
+            ),
+            result.first()
+        )
+    }
+
+    @Test
+    fun `headerContains adds assertion that checks if the header contains the value`() {
+        val sut = AssertionsBuilder()
+        sut.headerContains("any_header", "any_value")
+        val result = sut.build()
+
+        assertEquals(
+            SyntheticsAssertion(
+                SyntheticsAssertionTarget()
+                    .property("any_header")
+                    .operator(SyntheticsAssertionOperator.CONTAINS)
+                    .target("any_value")
+                    .type(SyntheticsAssertionType.HEADER)
+            ),
+            result.first()
+        )
+    }
+
+    @Test
+    fun `bodyContainsJsonPath adds assertion that validates the value stored in the given json path against the value provided`() {
+        val sut = AssertionsBuilder()
+        sut.bodyContainsJsonPath("any_json_path", "any_value")
+        val result = sut.build()
+
+        assertEquals(
+            SyntheticsAssertion(
+                SyntheticsAssertionJSONPathTarget()
+                    .operator(SyntheticsAssertionJSONPathOperator.VALIDATES_JSON_PATH)
+                    .type(SyntheticsAssertionType.BODY)
+                    .target(
+                        SyntheticsAssertionJSONPathTargetTarget()
+                            .jsonPath("any_json_path")
+                            .operator("contains")
+                            .targetValue("any_value")
+
+                    )
+            ),
+            result.first()
+        )
+    }
+
+    @Test
+    fun `bodyContains adds assertion that checks if the body contains the given raw value`() {
+        val sut = AssertionsBuilder()
+        sut.bodyContains("any_value")
+        val result = sut.build()
+
+        assertEquals(
+            SyntheticsAssertion(
+                SyntheticsAssertionTarget()
+                    .operator(SyntheticsAssertionOperator.CONTAINS)
+                    .target("any_value")
+                    .type(SyntheticsAssertionType.BODY)
+            ),
+            result.first()
+        )
+    }
+
+    @Test
+    fun `build returns list of assertions`() {
+        val sut = AssertionsBuilder()
+        sut.statusCode(200)
+        sut.headerContains("any_header", "any_value")
+        sut.bodyContainsJsonPath("any_json_path", "any_value")
+        sut.bodyContains("any_value")
+        val result = sut.build()
+
+        assertEquals(4, result.count())
+    }
+}

--- a/src/test/kotlin/com/personio/synthetics/builder/RequestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/RequestBuilderTest.kt
@@ -1,0 +1,87 @@
+package com.personio.synthetics.builder
+
+import com.datadog.api.client.v1.model.SyntheticsTestRequestBodyType
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class RequestBuilderTest {
+    @Test
+    fun `headers appends given headers`() {
+        val sut = RequestBuilder()
+        sut.headers(
+            mapOf("any_header" to "any_value")
+        )
+        val result = sut.build()
+
+        assertEquals(
+            mapOf("any_header" to "any_value"),
+            result.headers
+        )
+    }
+
+    @Test
+    fun `cookies add a Cookie header`() {
+        val sut = RequestBuilder()
+        sut.cookies("any_cookie")
+        val result = sut.build()
+
+        assertEquals(
+            mapOf("Cookie" to "any_cookie"),
+            result.headers
+        )
+    }
+
+    @Test
+    fun `url sets url`() {
+        val sut = RequestBuilder()
+        sut.url("any_url")
+        val result = sut.build()
+
+        assertEquals("any_url", result.url)
+    }
+
+    @Test
+    fun `method sets http method`() {
+        val sut = RequestBuilder()
+        sut.method(RequestMethod.POST)
+        val result = sut.build()
+
+        assertEquals("POST", result.method)
+    }
+
+    @Test
+    fun `body sets body`() {
+        val sut = RequestBuilder()
+        sut.body("any_body")
+        val result = sut.build()
+
+        assertEquals("any_body", result.body)
+    }
+
+    @Test
+    fun `bodyType sets bodyType`() {
+        val sut = RequestBuilder()
+        sut.bodyType(SyntheticsTestRequestBodyType.APPLICATION_JSON)
+        val result = sut.build()
+
+        assertEquals(
+            SyntheticsTestRequestBodyType.APPLICATION_JSON,
+            result.bodyType
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `followRedirects sets bodyType`(value: Boolean) {
+        val sut = RequestBuilder()
+        sut.followRedirects(value)
+        val result = sut.build()
+
+        assertEquals(
+            value,
+            result.followRedirects
+        )
+    }
+}

--- a/src/test/kotlin/com/personio/synthetics/builder/RequestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/RequestBuilderTest.kt
@@ -74,7 +74,7 @@ class RequestBuilderTest {
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
-    fun `followRedirects sets bodyType`(value: Boolean) {
+    fun `followRedirects sets followRedirects`(value: Boolean) {
         val sut = RequestBuilder()
         sut.followRedirects(value)
         val result = sut.build()
@@ -82,6 +82,19 @@ class RequestBuilderTest {
         assertEquals(
             value,
             result.followRedirects
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `ignoreServerCertificateError sets allowInsecure`(value: Boolean) {
+        val sut = RequestBuilder()
+        sut.ignoreServerCertificateError(value)
+        val result = sut.build()
+
+        assertEquals(
+            value,
+            result.allowInsecure
         )
     }
 }

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
@@ -1,0 +1,281 @@
+package com.personio.synthetics.builder
+
+import com.datadog.api.client.v1.model.SyntheticsAPIStep
+import com.datadog.api.client.v1.model.SyntheticsConfigVariable
+import com.datadog.api.client.v1.model.SyntheticsConfigVariableType
+import com.personio.synthetics.builder.api.StepsBuilder
+import com.personio.synthetics.client.SyntheticsApiClient
+import com.personio.synthetics.config.getConfigFromFile
+import com.personio.synthetics.model.config.Location
+import com.personio.synthetics.model.config.Timeframe
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito
+import org.mockito.kotlin.whenever
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.ZoneId
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class SyntheticMultiStepApiTestBuilderTest {
+    private lateinit var sut: SyntheticMultiStepApiTestBuilder
+
+    @BeforeEach
+    fun prepareSut() {
+        val apiClientMock = Mockito.mock(SyntheticsApiClient::class.java)
+        sut = SyntheticMultiStepApiTestBuilder(
+            "any_name",
+            getConfigFromFile("config-unit-test.yaml").defaults,
+            apiClientMock
+        )
+    }
+
+    @Test
+    fun `monitorName sets monitor name`() {
+        sut.monitorName("any_name")
+        val result = sut.build()
+
+        assertEquals(
+            "any_name",
+            result.options.monitorName
+        )
+    }
+
+    @Test
+    fun `alertMessage appends formatted alert message`() {
+        sut.alertMessage("any_failure_message", "any_alert_medium")
+        val result = sut.build()
+
+        assertEquals(
+            "any_alert_medium {{#is_alert}} any_failure_message {{/is_alert}} ",
+            result.message
+        )
+    }
+
+    @Test
+    fun `recoveryMessage appends formatted recovery message`() {
+        sut.recoveryMessage("any_recovery_message")
+        val result = sut.build()
+
+        assertEquals(
+            " {{#is_recovery}} any_recovery_message {{/is_recovery}} ",
+            result.message
+        )
+    }
+
+    @Test
+    fun `tags sets tags`() {
+        sut.tags("any_tag1", "any_tag2")
+        val result = sut.build()
+
+        assertEquals(
+            listOf("any_tag1", "any_tag2"),
+            result.tags
+        )
+    }
+
+    @Test
+    fun `publicLocations sets locations`() {
+        sut.publicLocations(Location.FRANKFURT_AWS, Location.LONDON_AWS)
+        val result = sut.build()
+
+        assertEquals(
+            listOf(Location.FRANKFURT_AWS.value, Location.LONDON_AWS.value),
+            result.locations
+        )
+    }
+
+    @Test
+    fun `testFrequency sets options tickEvery`() {
+        sut.testFrequency(5.minutes)
+        val result = sut.build()
+
+        assertEquals(
+            5.minutes.inWholeSeconds,
+            result.options.tickEvery
+        )
+    }
+
+    @Test
+    fun `testFrequency throws IllegalArgumentException when frequency is less than 30 seconds`() {
+        assertThrows<IllegalArgumentException> {
+            sut.testFrequency(29.seconds)
+        }
+    }
+
+    @Test
+    fun `testFrequency throws IllegalArgumentException when frequency is more than 7 days`() {
+        assertThrows<IllegalArgumentException> {
+            sut.testFrequency((604800 + 1).seconds) // 7 days + 1 second
+        }
+    }
+
+    @Test
+    fun `advancedScheduling sets the advanced scheduling configuration`() {
+        sut.advancedScheduling(
+            Timeframe(
+                from = LocalTime.of(0, 1),
+                to = LocalTime.of(23, 59),
+                DayOfWeek.MONDAY,
+                DayOfWeek.SUNDAY
+            ),
+            timezone = ZoneId.of("Europe/Dublin")
+        )
+        val result = sut.build()
+
+        assertEquals(1, result.options.scheduling.timeframes[0].day)
+        assertEquals("00:01", result.options.scheduling.timeframes[0].from)
+        assertEquals("23:59", result.options.scheduling.timeframes[0].to)
+        assertEquals(7, result.options.scheduling.timeframes[1].day)
+        assertEquals("00:01", result.options.scheduling.timeframes[1].from)
+        assertEquals("23:59", result.options.scheduling.timeframes[1].to)
+        assertEquals("Europe/Dublin", result.options.scheduling.timezone)
+    }
+
+    @Test
+    fun `advancedScheduling function sets the advanced scheduling with default timezone in the test config`() {
+        sut.advancedScheduling(
+            Timeframe(
+                from = LocalTime.of(0, 1),
+                to = LocalTime.of(23, 59),
+                DayOfWeek.MONDAY
+            )
+        )
+        val result = sut.build()
+
+        assertNotNull(result.options.scheduling.timezone)
+        assertTrue(result.options.scheduling.timezone.isNotEmpty())
+    }
+
+    @Test
+    fun `uuidVariable adds variable of UUID pattern`() {
+        sut.uuidVariable("any_name")
+        val result = sut.build()
+
+        assertTrue(
+            result.config.configVariables.contains(
+                SyntheticsConfigVariable()
+                    .name("ANY_NAME")
+                    .type(SyntheticsConfigVariableType.TEXT)
+                    .example("")
+                    .pattern("{{ uuid }}")
+            )
+        )
+    }
+
+    @Test
+    fun `timestampPatternVariable adds variable of timestamp pattern`() {
+        sut.timestampPatternVariable("any_name", 5.minutes, "prefix-", "-suffix")
+        val result = sut.build()
+
+        assertTrue(
+            result.config.configVariables.contains(
+                SyntheticsConfigVariable()
+                    .name("ANY_NAME")
+                    .pattern("prefix-{{ timestamp(300000, ms) }}-suffix")
+                    .type(SyntheticsConfigVariableType.TEXT)
+                    .example("")
+            )
+        )
+    }
+
+    @Test
+    fun `datePatternVariable adds variable of timestamp pattern`() {
+        sut.datePatternVariable("any_name", 5.days, "YYYY-MM-DD", "prefix-", "-suffix")
+        val result = sut.build()
+
+        assertTrue(
+            result.config.configVariables.contains(
+                SyntheticsConfigVariable()
+                    .name("ANY_NAME")
+                    .pattern("prefix-{{ date(432000s, YYYY-MM-DD) }}-suffix")
+                    .type(SyntheticsConfigVariableType.TEXT)
+                    .example("")
+            )
+        )
+    }
+
+    @Test
+    fun `alphanumericPatternVariable adds variable of timestamp pattern`() {
+        sut.alphanumericPatternVariable("any_name", 10, "prefix-", "-suffix")
+        val result = sut.build()
+
+        assertTrue(
+            result.config.configVariables.contains(
+                SyntheticsConfigVariable()
+                    .name("ANY_NAME")
+                    .pattern("prefix-{{ alphanumeric(10) }}-suffix")
+                    .type(SyntheticsConfigVariableType.TEXT)
+                    .example("")
+            )
+        )
+    }
+
+    @Test
+    fun `alphabeticPatternVariable adds variable of timestamp pattern`() {
+        sut.alphabeticPatternVariable("any_name", 10, "prefix-", "-suffix")
+        val result = sut.build()
+
+        assertTrue(
+            result.config.configVariables.contains(
+                SyntheticsConfigVariable()
+                    .name("ANY_NAME")
+                    .pattern("prefix-{{ alphabetic(10) }}-suffix")
+                    .type(SyntheticsConfigVariableType.TEXT)
+                    .example("")
+            )
+        )
+    }
+
+    @Test
+    fun `numericPatternVariable adds variable of timestamp pattern`() {
+        sut.numericPatternVariable("any_name", 10, "prefix-", "-suffix")
+        val result = sut.build()
+
+        assertTrue(
+            result.config.configVariables.contains(
+                SyntheticsConfigVariable()
+                    .name("ANY_NAME")
+                    .pattern("prefix-{{ numeric(10) }}-suffix")
+                    .type(SyntheticsConfigVariableType.TEXT)
+                    .example("")
+            )
+        )
+    }
+
+    @Test
+    fun `steps sets provided list of steps`() {
+        sut.steps(
+            listOf(
+                SyntheticsAPIStep(),
+                SyntheticsAPIStep()
+            )
+        )
+        val result = sut.build()
+
+        assertEquals(
+            2,
+            result.config.steps.count()
+        )
+    }
+
+    @Test
+    fun `steps evaluates provided lambda and sets steps`() {
+        val stepsBuilderMock = Mockito.mock(StepsBuilder::class.java)
+        whenever(stepsBuilderMock.build())
+            .thenReturn(listOf(SyntheticsAPIStep(), SyntheticsAPIStep()))
+        sut.steps(stepsBuilderMock) {}
+        val result = sut.build()
+
+        assertEquals(
+            2,
+            result.config.steps.count()
+        )
+    }
+}

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
@@ -1,0 +1,163 @@
+package com.personio.synthetics.builder.api
+
+import com.datadog.api.client.v1.model.SyntheticsAPIStepSubtype
+import com.datadog.api.client.v1.model.SyntheticsAssertion
+import com.datadog.api.client.v1.model.SyntheticsParsingOptions
+import com.datadog.api.client.v1.model.SyntheticsTestRequest
+import com.personio.synthetics.builder.AssertionsBuilder
+import com.personio.synthetics.builder.RequestBuilder
+import com.personio.synthetics.builder.parsing.ParsingOptionsBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.Mockito
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class StepBuilderTest {
+    @Test
+    fun `extract sets the extracted values properly`() {
+        val sut = StepBuilder(
+            "any_name",
+            makeRequestBuilderHappyPathMock(),
+            makeAssertionBuilderMock(),
+            makeParsingOptionsBuilderMock(
+                SyntheticsParsingOptions()
+            )
+        )
+        sut.request { }
+        sut.extract("any_variable_name") {}
+        val result = sut.build()
+
+        assertEquals(1, result.extractedValues.count())
+    }
+
+    @Test
+    fun `extract sets the extracted values to null when no parsing options provided`() {
+        val sut = StepBuilder(
+            "any_name",
+            makeRequestBuilderHappyPathMock(),
+            makeAssertionBuilderMock(),
+            makeParsingOptionsBuilderMock()
+        )
+        sut.request { }
+        sut.extract("any_variable_name") {}
+        val result = sut.build()
+
+        assertNull(result.extractedValues)
+    }
+
+    @Test
+    fun `request sets the request in SyntheticsAPIStep`() {
+        val requestBuilderMock = makeRequestBuilderHappyPathMock()
+        val sut = StepBuilder("any_name", requestBuilderMock)
+        sut.request { }
+
+        val result = sut.build()
+        verify(requestBuilderMock, times(1)).build()
+        assertNotNull(result.request)
+    }
+
+    @Test
+    fun `assertions sets assertions properly`() {
+        val assertionsMock = makeAssertionBuilderMock(
+            listOf(SyntheticsAssertion(), SyntheticsAssertion())
+        )
+        val sut = StepBuilder("any_name", RequestBuilder(), assertionsMock)
+        sut.assertions { }
+        sut.request { }
+        val result = sut.build()
+
+        verify(assertionsMock, times(1)).build()
+        assertEquals(2, result.assertions.count())
+    }
+
+    @Test
+    fun `build sets HTTP step subtype`() {
+        val sut = StepBuilder("any_name", RequestBuilder())
+        sut.request { }
+        val result = sut.build()
+
+        assertEquals(SyntheticsAPIStepSubtype.HTTP, result.subtype)
+    }
+
+    @Test
+    fun `build sets step name properly`() {
+        val sut = StepBuilder("any_name", RequestBuilder())
+        sut.request { }
+        val result = sut.build()
+
+        assertEquals("any_name", result.name)
+    }
+
+    @Test
+    fun `build sets empty assertions by default`() {
+        val assertionsMock = makeAssertionBuilderMock()
+        val sut = StepBuilder("any_name", RequestBuilder(), assertionsMock)
+        sut.assertions { }
+        sut.request { }
+        val result = sut.build()
+
+        verify(assertionsMock, times(1)).build()
+        assertTrue(result.assertions.isEmpty())
+    }
+
+    @Test
+    fun `build throws IllegalStateException when request is null`() {
+        val requestBuilderMock = Mockito.mock(RequestBuilder::class.java)
+        whenever(requestBuilderMock.build())
+            .thenReturn(null)
+        val sut = StepBuilder("any_name", requestBuilderMock)
+
+        assertThrows<IllegalStateException> {
+            sut.build()
+        }
+    }
+
+    @Test
+    fun `build sets isCritical to null when allowFailure is false`() {
+        val sut = StepBuilder("any_name", makeRequestBuilderHappyPathMock())
+        sut.allowFailure = false
+        sut.isCritical = true
+        sut.request { }
+        val result = sut.build()
+
+        assertNull(result.isCritical)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `build sets isCritical to the provided value when allowFailure is true`(isCritical: Boolean) {
+        val sut = StepBuilder("any_name", makeRequestBuilderHappyPathMock())
+        sut.allowFailure = true
+        sut.isCritical = isCritical
+        sut.request { }
+        val result = sut.build()
+
+        assertEquals(isCritical, result.isCritical)
+    }
+
+    private fun makeRequestBuilderHappyPathMock(): RequestBuilder {
+        val mock = Mockito.mock(RequestBuilder::class.java)
+        whenever(mock.build()).thenReturn(SyntheticsTestRequest())
+        return mock
+    }
+
+    private fun makeAssertionBuilderMock(assertionsToReturn: List<SyntheticsAssertion> = listOf()): AssertionsBuilder {
+        val mock = Mockito.mock(AssertionsBuilder::class.java)
+        whenever(mock.build()).thenReturn(assertionsToReturn)
+        return mock
+    }
+
+    private fun makeParsingOptionsBuilderMock(parsingOptionsToReturn: SyntheticsParsingOptions? = null): ParsingOptionsBuilder {
+        val mock = Mockito.mock(ParsingOptionsBuilder::class.java)
+        whenever(mock.build()).thenReturn(parsingOptionsToReturn)
+        return mock
+    }
+}

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepsBuilderTest.kt
@@ -1,0 +1,25 @@
+package com.personio.synthetics.builder.api
+
+import com.datadog.api.client.v1.model.SyntheticsAPIStep
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.kotlin.whenever
+
+class StepsBuilderTest {
+    @Test
+    fun `step adds a step to the list`() {
+        val sut = StepsBuilder()
+        sut.step("any_name", makeStepBuilderMock(SyntheticsAPIStep())) {}
+        sut.step("any_name", makeStepBuilderMock(SyntheticsAPIStep())) {}
+        val result = sut.build()
+
+        assertEquals(2, result.count())
+    }
+
+    private fun makeStepBuilderMock(stepToReturn: SyntheticsAPIStep): StepBuilder {
+        val mock = Mockito.mock(StepBuilder::class.java)
+        whenever(mock.build()).thenReturn(stepToReturn)
+        return mock
+    }
+}

--- a/src/test/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilderTest.kt
@@ -1,0 +1,126 @@
+package com.personio.synthetics.builder.parsing
+
+import com.datadog.api.client.v1.model.SyntheticsGlobalVariableParseTestOptionsType
+import com.datadog.api.client.v1.model.SyntheticsGlobalVariableParserType
+import com.datadog.api.client.v1.model.SyntheticsParsingOptions
+import com.datadog.api.client.v1.model.SyntheticsVariableParser
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class ParsingOptionsBuilderTest {
+    @Test
+    fun `variable sets variable name`() {
+        val sut = ParsingOptionsBuilder()
+        sut.bodyJsonPath("any")
+        sut.variable("any_name")
+
+        assertEquals("any_name", sut.build()!!.name)
+    }
+
+    @Test
+    fun `build throws IllegalArgumentException when no parsing options set`() {
+        val sut = ParsingOptionsBuilder()
+        sut.variable("any_name")
+
+        assertThrows<IllegalStateException> {
+            sut.build()
+        }
+    }
+
+    @Test
+    fun `build throws IllegalArgumentException when no variable name set`() {
+        val sut = ParsingOptionsBuilder()
+
+        assertThrows<IllegalStateException> {
+            sut.build()
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `bodyJsonPath returns parsing options with JSON_PATH parser type and HTTP_BODY type`(secure: Boolean) {
+        val sut = ParsingOptionsBuilder()
+        sut.variable("any_name")
+        sut.bodyJsonPath("any_json_path", secure)
+
+        assertEquals(
+            SyntheticsParsingOptions()
+                .name("any_name")
+                .parser(
+                    SyntheticsVariableParser()
+                        .type(SyntheticsGlobalVariableParserType.JSON_PATH)
+                        .value("any_json_path")
+                )
+                .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_BODY)
+                .secure(secure),
+            sut.build()
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `bodyRegex returns parsing options with REGEX parser type and HTTP_BODY type`(secure: Boolean) {
+        val sut = ParsingOptionsBuilder()
+        sut.variable("any_name")
+        sut.bodyRegex("any_regex", secure)
+
+        assertEquals(
+            SyntheticsParsingOptions()
+                .name("any_name")
+                .parser(
+                    SyntheticsVariableParser()
+                        .type(SyntheticsGlobalVariableParserType.REGEX)
+                        .value("any_regex")
+                )
+                .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_BODY)
+                .secure(secure),
+            sut.build()
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `header returns parsing options with RAW parser type and HTTP_HEADER type`(secure: Boolean) {
+        val sut = ParsingOptionsBuilder()
+        sut.variable("any_name")
+        sut.header("any_header_name", secure)
+
+        assertEquals(
+            SyntheticsParsingOptions()
+                .name("any_name")
+                .field("any_header_name")
+                .parser(
+                    SyntheticsVariableParser()
+                        .type(SyntheticsGlobalVariableParserType.RAW)
+                )
+                .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_HEADER)
+                .secure(secure),
+            sut.build()
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `headerRegex returns parsing options with REGEX parser type and HTTP_HEADER type`(secure: Boolean) {
+        val sut = ParsingOptionsBuilder()
+        sut.variable("any_name")
+        sut.headerRegex("any_header_name", "any_regex", secure)
+
+        assertEquals(
+            SyntheticsParsingOptions()
+                .name("any_name")
+                .field("any_header_name")
+                .parser(
+                    SyntheticsVariableParser()
+                        .type(SyntheticsGlobalVariableParserType.REGEX)
+                        .value("any_regex")
+                )
+                .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_HEADER)
+                .secure(secure),
+            sut.build()
+        )
+    }
+}

--- a/src/test/kotlin/com/personio/synthetics/config/BrowserTestConfigTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/config/BrowserTestConfigTest.kt
@@ -87,19 +87,6 @@ internal class BrowserTestConfigTest {
     }
 
     @Test
-    fun `advancedScheduling function throws exception when from time is later than to time`() {
-        assertThrows(IllegalArgumentException::class.java) {
-            browserTest.advancedScheduling(
-                Timeframe(
-                    from = LocalTime.of(20, 0),
-                    to = LocalTime.of(9, 0),
-                    DayOfWeek.MONDAY
-                )
-            )
-        }
-    }
-
-    @Test
     fun `retry function sets the retry count and interval in the test config`() {
         browserTest.retry(1, 60.milliseconds)
 

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -1,0 +1,89 @@
+package com.personio.synthetics.e2e
+
+import com.datadog.api.client.v1.model.SyntheticsTestRequestBodyType
+import com.personio.synthetics.builder.RequestMethod
+import com.personio.synthetics.dsl.syntheticMultiStepApiTest
+import com.personio.synthetics.model.config.Location
+import com.personio.synthetics.model.config.Timeframe
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.ZoneId
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class E2EMultiStepApiTest {
+    /**
+     * This test creates a Synthetic Multi-Step API test in Datadog.
+     */
+    @Test
+    fun `create mutli-step api synthetic test`() {
+        syntheticMultiStepApiTest("[Multi-Step] Synthetic-Test-As-Code") {
+            alertMessage("Test failed", "@slack-test_slack_channel")
+            recoveryMessage("Test recovered")
+            tags("env:qa")
+            publicLocations(Location.IRELAND_AWS, Location.N_CALIFORNIA_AWS, Location.MUMBAI_AWS)
+            testFrequency(1.minutes)
+            advancedScheduling(
+                Timeframe(
+                    from = LocalTime.of(0, 1),
+                    to = LocalTime.of(23, 59),
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                    DayOfWeek.FRIDAY
+                ),
+                timezone = ZoneId.of("Africa/Bissau")
+            )
+            monitorName("Test Monitor Name")
+            alphabeticPatternVariable("ALPHABETIC_PATTERN", 5)
+            alphanumericPatternVariable("ALPHANUMERIC_PATTERN", 6)
+            useGlobalVariable("TEST_PASSWORD")
+            textVariable("TEXT_VARIABLE", "test")
+            numericPatternVariable(
+                name = "NUMERIC_PATTERN",
+                characterLength = 4,
+                prefix = "test"
+            )
+            datePatternVariable(
+                name = "DATE_PATTERN",
+                duration = (-1).days,
+                format = "MM-DD-YYYY"
+            )
+            timestampPatternVariable(
+                name = "TIMESTAMP_PATTERN",
+                duration = 10.seconds
+            )
+            steps {
+                step("Do http request") {
+                    request {
+                        url("https://synthetic-test.personio.de/")
+                        method(RequestMethod.POST)
+                        bodyType(SyntheticsTestRequestBodyType.APPLICATION_JSON)
+                        body(
+                            """
+                            {
+                                "key": "value",
+                            }
+                            """.trimIndent()
+                        )
+                        headers(
+                            mapOf(
+                                "Content-Type" to "application/json"
+                            )
+                        )
+                        assertions {
+                            statusCode(200)
+                            bodyContainsJsonPath("\$.success", "true")
+                            bodyContains("some_data")
+                            headerContains("set-cookie", "cookie_name")
+                        }
+                        extract("COOKIE_VARIABLE") {
+                            headerRegex("set-cookie", "(?<=cookie_name\\=)[^;]+(?=;)")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -72,6 +72,7 @@ class E2EMultiStepApiTest {
                                 "Content-Type" to "application/json"
                             )
                         )
+                        ignoreServerCertificateError(true)
                         assertions {
                             statusCode(200)
                             bodyContainsJsonPath("\$.success", "true")

--- a/src/test/kotlin/com/personio/synthetics/model/config/TimeframeTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/model/config/TimeframeTest.kt
@@ -1,0 +1,33 @@
+package com.personio.synthetics.model.config
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.lang.IllegalArgumentException
+import java.time.DayOfWeek
+import java.time.LocalTime
+
+class TimeframeTest {
+    @Test
+    fun `invoke throws IllegalArgumentException when from time is later than to time`() {
+        assertThrows<IllegalArgumentException> {
+            Timeframe(
+                from = LocalTime.of(19, 0),
+                to = LocalTime.of(17, 0),
+                DayOfWeek.MONDAY,
+                DayOfWeek.SUNDAY
+            )
+        }
+    }
+
+    @Test
+    fun `invoke throws IllegalArgumentException when from time equals to to time`() {
+        assertThrows<IllegalArgumentException> {
+            Timeframe(
+                from = LocalTime.of(23, 1),
+                to = LocalTime.of(23, 1),
+                DayOfWeek.MONDAY,
+                DayOfWeek.SUNDAY
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Why

To have [Multi-Step API Synthetic test](https://docs.datadoghq.com/synthetics/multistep/?tab=requestoptions) support in this library.

## Scope

This MR introduces the Multi-Step API test support by implementing the Kotlin DSL using the Builder pattern.

Without it, I would have added a lot of duplicated code because of the similar, although different, set of classes the DataDog client provides.

This approach leaves room for refactoring the existing Browser test implementation with the proposed pattern.