### PR TITLE
docs: add deprecation warning for BrowserTest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [Unreleased] - yyyy-mm-dd
 ### New features & improvements
 - Add support for Multi-Step API Synthetic Tests
+- Add deprecation warnings for BrowserTest
 
 ### Breaking changes
 

--- a/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
+++ b/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
@@ -19,7 +19,7 @@ import com.personio.synthetics.config.loadConfiguration
  * @param name Name of the test
  * @param steps Calls the added steps and configuration functions of the test
  */
-@Deprecated(message="Planned for removal in 3.x.x")
+@Deprecated(message = "Planned for removal in 3.x.x")
 inline fun syntheticBrowserTest(name: String, steps: BrowserTest.() -> Unit) {
     check(name.isNotBlank()) {
         "The test's name must not be empty."
@@ -46,7 +46,8 @@ fun getCredentialsProvider(): CredentialsProvider {
  * Deprecation notice: In future releases this class will be replaced by
  * SyntheticTestBuilder (or similar).
  */
-@Deprecated(message="Planned for removal in 3.x.x") class BrowserTest(testName: String, private val syntheticsApiClient: SyntheticsApiClient, private val defaultSettings: Defaults = Config.testConfig.defaults) : SyntheticsBrowserTest() {
+@Deprecated(message = "Planned for removal in 3.x.x")
+class BrowserTest(testName: String, private val syntheticsApiClient: SyntheticsApiClient, private val defaultSettings: Defaults = Config.testConfig.defaults) : SyntheticsBrowserTest() {
     init {
         name = testName
         locations = defaultSettings.runLocations
@@ -60,7 +61,9 @@ fun getCredentialsProvider(): CredentialsProvider {
      * it will update the test, else it will create a new test
      * @return SyntheticsBrowserTest object
      */
-    @PublishedApi @Deprecated(message="Planned for removal in 3.x.x") internal fun createBrowserTest(): SyntheticsBrowserTest {
+    @PublishedApi
+    @Deprecated(message = "Planned for removal in 3.x.x")
+    internal fun createBrowserTest(): SyntheticsBrowserTest {
         val testId = getTestId()
         return if (testId != null) {
             syntheticsApiClient.updateBrowserTest(testId, this)

--- a/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
+++ b/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
@@ -12,10 +12,14 @@ import com.personio.synthetics.config.loadConfiguration
 
 /**
  * Creates a synthetic browser test with the added configurations (if any) and steps in Datadog
- * The default configurations for the tests are loaded from the configuration file in resources
+ * The default configurations for the tests are loaded from the configuration file in resources.
+ *
+ * Deprecation notice: In future releases this method will be replaced by one that
+ * uses SyntheticTestBuilder or similar.
  * @param name Name of the test
  * @param steps Calls the added steps and configuration functions of the test
  */
+@Deprecated(message="Planned for removal in 3.x.x")
 inline fun syntheticBrowserTest(name: String, steps: BrowserTest.() -> Unit) {
     check(name.isNotBlank()) {
         "The test's name must not be empty."
@@ -37,9 +41,12 @@ fun getCredentialsProvider(): CredentialsProvider {
 }
 
 /**
- * Synthetic browser test client for the API calls with the Datadog
+ * Synthetic browser test client for the API calls with the Datadog.
+ *
+ * Deprecation notice: In future releases this class will be replaced by
+ * SyntheticTestBuilder (or similar).
  */
-class BrowserTest(testName: String, private val syntheticsApiClient: SyntheticsApiClient, private val defaultSettings: Defaults = Config.testConfig.defaults) : SyntheticsBrowserTest() {
+@Deprecated(message="Planned for removal in 3.x.x") class BrowserTest(testName: String, private val syntheticsApiClient: SyntheticsApiClient, private val defaultSettings: Defaults = Config.testConfig.defaults) : SyntheticsBrowserTest() {
     init {
         name = testName
         locations = defaultSettings.runLocations
@@ -53,7 +60,7 @@ class BrowserTest(testName: String, private val syntheticsApiClient: SyntheticsA
      * it will update the test, else it will create a new test
      * @return SyntheticsBrowserTest object
      */
-    @PublishedApi internal fun createBrowserTest(): SyntheticsBrowserTest {
+    @PublishedApi @Deprecated(message="Planned for removal in 3.x.x") internal fun createBrowserTest(): SyntheticsBrowserTest {
         val testId = getTestId()
         return if (testId != null) {
             syntheticsApiClient.updateBrowserTest(testId, this)

--- a/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
+++ b/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
@@ -19,7 +19,7 @@ import com.personio.synthetics.config.loadConfiguration
  * @param name Name of the test
  * @param steps Calls the added steps and configuration functions of the test
  */
-@Deprecated(message = "Planned for removal in 3.x.x")
+@Deprecated(message = "This function will have its package and signature changed in 3.x.x")
 inline fun syntheticBrowserTest(name: String, steps: BrowserTest.() -> Unit) {
     check(name.isNotBlank()) {
         "The test's name must not be empty."

--- a/src/main/kotlin/com/personio/synthetics/config/BrowserTestConfig.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/BrowserTestConfig.kt
@@ -1,5 +1,11 @@
 package com.personio.synthetics.config
 
+/**
+ * Code here is mostly a copy of what is available in SyntheticTestBuilder,
+ * and will be deleted when 3.x.x is available.
+ * @see com.personio.synthetics.builder.SyntheticTestBuilder
+ */
+
 import com.datadog.api.client.v1.model.SyntheticsDeviceID
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsScheduling
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsSchedulingTimeframe
@@ -116,6 +122,7 @@ fun BrowserTest.minLocationFailed(minLocationFailed: Long) = apply {
  * @param monitorName The monitor name of the test
  * @return BrowserTest object with monitor name set
  */
+
 fun BrowserTest.monitorName(monitorName: String) = apply {
     options.monitorName = monitorName
 }

--- a/src/main/kotlin/com/personio/synthetics/config/BrowserTestConfig.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/BrowserTestConfig.kt
@@ -1,8 +1,8 @@
 package com.personio.synthetics.config
 
 /**
- * Code here is mostly a copy of what is available in SyntheticTestBuilder,
- * and will be deleted when 3.x.x is available.
+ * This code will be deprecated in the future releases as it is a duplicate of SyntheticTestBuilder.
+ * Most functions are already available in SyntheticTestBuilder.
  * @see com.personio.synthetics.builder.SyntheticTestBuilder
  */
 


### PR DESCRIPTION
Add a deprecation warning to BrowserTest as it will be replaced by a Builder-based strategy (similar to multi-step API tests)