### PR TITLE
Add `status()` function to set SyntheticsTestPauseStatus property of a synthetic test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
-- Add handy `env()` and `team()` functions for adding corresponding Datadog `key:value` tags  
+- Add handy `env()` and `team()` functions for adding corresponding Datadog `key:value` tags ([#126](https://github.com/personio/datadog-synthetic-test-support/pull/126))
+- Add `status()` function to set the SyntheticTestPauseStatus property ([#127](https://github.com/personio/datadog-synthetic-test-support/pull/127))
 
 ### Bug fixes
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Start using the library in a gradle project by following the steps below:
     syntheticMultiStepApiTest("Test Login to the app") {
         env("qa")
         team("team-one")
+        status(SyntheticsTestPauseStatus.LIVE)
         publicLocations(Location.FRANKFURT_AWS)
         testFrequency(5.minutes)
         retry(1, 600.milliseconds)

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilder.kt
@@ -7,7 +7,6 @@ import com.datadog.api.client.v1.model.SyntheticsAPITestType
 import com.datadog.api.client.v1.model.SyntheticsConfigVariable
 import com.datadog.api.client.v1.model.SyntheticsConfigVariableType
 import com.datadog.api.client.v1.model.SyntheticsTestDetailsSubType
-import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
 import com.personio.synthetics.builder.api.StepsBuilder
 import com.personio.synthetics.client.SyntheticsApiClient
 import com.personio.synthetics.config.Defaults
@@ -36,7 +35,7 @@ class SyntheticMultiStepApiTestBuilder(
             SyntheticsAPITestType.API
         )
             .tags(parameters.tags)
-            .status(SyntheticsTestPauseStatus.PAUSED)
+            .status(status)
             .subtype(SyntheticsTestDetailsSubType.MULTI)
 
     /**

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
@@ -6,6 +6,7 @@ import com.datadog.api.client.v1.model.SyntheticsTestOptionsMonitorOptions
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsRetry
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsScheduling
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsSchedulingTimeframe
+import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
 import com.personio.synthetics.client.SyntheticsApiClient
 import com.personio.synthetics.config.Defaults
 import com.personio.synthetics.domain.SyntheticTestParameters
@@ -34,6 +35,7 @@ abstract class SyntheticTestBuilder(
     protected var parameters: SyntheticTestParameters
     protected var options: SyntheticsTestOptions
     protected var locations: List<String> = defaults.runLocations
+    protected var status: SyntheticsTestPauseStatus = SyntheticsTestPauseStatus.PAUSED
 
     init {
         parameters = SyntheticTestParameters(
@@ -295,6 +297,10 @@ abstract class SyntheticTestBuilder(
         tags("team:$teamName")
     }
 
+    fun status(status: SyntheticsTestPauseStatus) {
+        this.status = status
+    }
+
     private fun getScaledDate(value: Duration): Pair<Long, String>? =
         value.getScaledValue(
             sequenceOf(DurationUnit.MILLISECONDS, DurationUnit.SECONDS, DurationUnit.MINUTES, DurationUnit.HOURS, DurationUnit.DAYS),
@@ -332,5 +338,6 @@ abstract class SyntheticTestBuilder(
             ?.id
 
     protected abstract fun addLocalVariable(name: String, pattern: String)
+
     abstract fun useGlobalVariable(name: String)
 }

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
@@ -3,6 +3,7 @@ package com.personio.synthetics.builder
 import com.datadog.api.client.v1.model.SyntheticsAPIStep
 import com.datadog.api.client.v1.model.SyntheticsConfigVariable
 import com.datadog.api.client.v1.model.SyntheticsConfigVariableType
+import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
 import com.personio.synthetics.builder.api.StepsBuilder
 import com.personio.synthetics.client.SyntheticsApiClient
 import com.personio.synthetics.config.getConfigFromFile
@@ -299,5 +300,19 @@ class SyntheticMultiStepApiTestBuilderTest {
 
         assertTrue(result.tags.contains("team:team-one"))
         assertTrue(result.tags.contains("team:team-two"))
+    }
+
+    @Test
+    fun `status is set to PAUSED by default`() {
+        val result = sut.build()
+        assertEquals(SyntheticsTestPauseStatus.PAUSED, result.status)
+    }
+
+    @Test
+    fun `status sets status of a test`() {
+        sut.status(SyntheticsTestPauseStatus.LIVE)
+        val result = sut.build()
+
+        assertEquals(SyntheticsTestPauseStatus.LIVE, result.status)
     }
 }

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -1,5 +1,6 @@
 package com.personio.synthetics.e2e
 
+import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
 import com.datadog.api.client.v1.model.SyntheticsTestRequestBodyType
 import com.personio.synthetics.builder.RequestMethod
 import com.personio.synthetics.dsl.syntheticMultiStepApiTest
@@ -23,6 +24,7 @@ class E2EMultiStepApiTest {
             alertMessage("Test failed", "@slack-test_slack_channel")
             recoveryMessage("Test recovered")
             env("qa")
+            status(SyntheticsTestPauseStatus.PAUSED)
             publicLocations(Location.IRELAND_AWS, Location.N_CALIFORNIA_AWS, Location.MUMBAI_AWS)
             testFrequency(1.minutes)
             advancedScheduling(


### PR DESCRIPTION
## Why

To support explicit synthetic test statuses.

## Scope

* This PR adds support for `status()` function that sets the SyntheticsTestPauseStatus.