### PR TITLE
Add minimum working implementation of the refactored browser test support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### New features & improvements
 - Add handy `env()` and `team()` functions for adding corresponding Datadog `key:value` tags ([#126](https://github.com/personio/datadog-synthetic-test-support/pull/126))
+- Add minimum working implementation of a refactored browser test support ([#129](https://github.com/personio/datadog-synthetic-test-support/pull/129))
 - Add `status()` function to set the SyntheticTestPauseStatus property ([#127](https://github.com/personio/datadog-synthetic-test-support/pull/127))
 
 ### Bug fixes
@@ -24,8 +25,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - In the future releases some BrowserTest-related methods (test config, variables, etc) will be replaced by the common methods from SyntheticTestBuilder.
 
 ### New features & improvements
-- Add support for Multi-Step API Synthetic Tests
-- Add deprecation warnings for BrowserTest
+- Add support for Multi-Step API Synthetic Tests ([#123](https://github.com/personio/datadog-synthetic-test-support/pull/123))
+- Add deprecation warnings for BrowserTest ([#124](https://github.com/personio/datadog-synthetic-test-support/pull/124))
 
 ## [2.0.0] - 2023-09-01
 ### Breaking changes

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilder.kt
@@ -1,0 +1,73 @@
+package com.personio.synthetics.builder
+
+import com.datadog.api.client.v1.model.SyntheticsBrowserTest
+import com.datadog.api.client.v1.model.SyntheticsBrowserTestConfig
+import com.datadog.api.client.v1.model.SyntheticsBrowserTestType
+import com.datadog.api.client.v1.model.SyntheticsBrowserVariable
+import com.datadog.api.client.v1.model.SyntheticsBrowserVariableType
+import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
+import com.datadog.api.client.v1.model.SyntheticsTestRequest
+import com.personio.synthetics.client.SyntheticsApiClient
+import com.personio.synthetics.config.Defaults
+import java.net.URL
+
+/**
+ * A builder for creating SyntheticsBrowserTest instances
+ */
+class SyntheticBrowserTestBuilder(
+    override val name: String,
+    defaults: Defaults,
+    apiClient: SyntheticsApiClient
+) : SyntheticTestBuilder(name, defaults, apiClient) {
+    private val config = SyntheticsBrowserTestConfig()
+
+    /**
+     * Builds a synthetic browser test
+     * @return SyntheticsBrowserTest object that contains a browser test
+     */
+    fun build(): SyntheticsBrowserTest =
+        SyntheticsBrowserTest(
+            config,
+            parameters.locations,
+            parameters.message,
+            name,
+            options,
+            SyntheticsBrowserTestType.BROWSER
+        )
+            .tags(parameters.tags)
+            .status(SyntheticsTestPauseStatus.PAUSED)
+
+    /**
+     * Sets the base url for the synthetic browser test
+     * @param url The base url for the test
+     */
+    fun baseUrl(url: URL) {
+        config.request(
+            SyntheticsTestRequest()
+                .method("GET")
+                .url(url.toString())
+        )
+    }
+
+    override fun addLocalVariable(name: String, pattern: String) {
+        config.addVariablesItem(
+            SyntheticsBrowserVariable()
+                .name(name.uppercase())
+                .type(SyntheticsBrowserVariableType.TEXT)
+                .pattern(pattern)
+                .example("")
+        )
+    }
+
+    override fun useGlobalVariable(name: String) {
+        val variableName = name.uppercase()
+        val variableId = getGlobalVariableId(variableName)
+        checkNotNull(variableId) { "The global variable $name to be used in the test doesn't exist in DataDog." }
+        config.addVariablesItem(
+            SyntheticsBrowserVariable()
+                .name(variableName)
+                .id(variableId)
+                .type(SyntheticsBrowserVariableType.GLOBAL)
+        )
+    }
+}

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
@@ -34,7 +34,6 @@ abstract class SyntheticTestBuilder(
 ) {
     protected var parameters: SyntheticTestParameters
     protected var options: SyntheticsTestOptions
-    protected var locations: List<String> = defaults.runLocations
     protected var status: SyntheticsTestPauseStatus = SyntheticsTestPauseStatus.PAUSED
 
     init {
@@ -173,8 +172,8 @@ abstract class SyntheticTestBuilder(
      * Allowed minimum location failed is between 1 and the number of locations where the test is configured to run
      */
     fun minLocationFailed(minLocationFailed: Long) {
-        require(minLocationFailed in 1..locations.count()) {
-            "Minimum location failed should be between 1 and the number of locations where the test is configured to run: ${locations.count()}."
+        require(minLocationFailed in 1..parameters.locations.count()) {
+            "Minimum location failed should be between 1 and the number of locations where the test is configured to run: ${parameters.locations.count()}."
         }
         options.minLocationFailed = minLocationFailed
     }
@@ -192,8 +191,8 @@ abstract class SyntheticTestBuilder(
      * @param monitorPriority The monitor priority of the test
      * Allowed monitor priority is one of [1, 2, 3, 4, 5]
      */
-    fun monitorPriority(monitorPriorities: MonitorPriority) {
-        options.monitorPriority = monitorPriorities.priorityValue
+    fun monitorPriority(monitorPriority: MonitorPriority) {
+        options.monitorPriority = monitorPriority.priorityValue
     }
 
     /**

--- a/src/main/kotlin/com/personio/synthetics/dsl/SyntheticTestDsl.kt
+++ b/src/main/kotlin/com/personio/synthetics/dsl/SyntheticTestDsl.kt
@@ -1,6 +1,8 @@
 package com.personio.synthetics.dsl
 
 import com.datadog.api.client.v1.model.SyntheticsAPITest
+import com.datadog.api.client.v1.model.SyntheticsBrowserTest
+import com.personio.synthetics.builder.SyntheticBrowserTestBuilder
 import com.personio.synthetics.builder.SyntheticMultiStepApiTestBuilder
 import com.personio.synthetics.client.AwsSecretsManagerCredentialsProvider
 import com.personio.synthetics.client.ConfigCredentialsProvider
@@ -36,6 +38,26 @@ fun syntheticMultiStepApiTest(name: String, init: SyntheticMultiStepApiTestBuild
         client.updateAPITest(testId, test)
     } else {
         client.createSyntheticsAPITest(test)
+    }
+}
+
+fun syntheticBrowserTest(name: String, init: SyntheticBrowserTestBuilder.() -> Unit): SyntheticsBrowserTest {
+    check(name.isNotBlank()) {
+        "The test's name must not be empty."
+    }
+
+    val (client, defaults) = getSyntheticsApiClientAndDefaults()
+
+    val test = SyntheticBrowserTestBuilder(name, defaults, client)
+        .apply(init)
+        .build()
+
+    val testId = getTestId(client, name)
+
+    return if (testId != null) {
+        client.updateBrowserTest(testId, test)
+    } else {
+        client.createSyntheticsBrowserTest(test)
     }
 }
 

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EBrowserTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EBrowserTest.kt
@@ -1,0 +1,65 @@
+package com.personio.synthetics.e2e
+
+import com.personio.synthetics.dsl.syntheticBrowserTest
+import com.personio.synthetics.model.config.Location
+import com.personio.synthetics.model.config.MonitorPriority
+import com.personio.synthetics.model.config.RenotifyInterval
+import com.personio.synthetics.model.config.Timeframe
+import org.junit.jupiter.api.Test
+import java.net.URL
+import java.time.DayOfWeek
+import java.time.LocalTime
+import java.time.ZoneId
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class E2EBrowserTest {
+    @Test
+    fun `create synthetic browser test`() {
+        syntheticBrowserTest("[Browser] Synthetic-Test-As-Code") {
+            alertMessage("Test Failed", "@slack-test_slack_channel")
+            recoveryMessage("Test recovered")
+            env("qa")
+            tags("synthetics-api")
+            baseUrl(URL("https://synthetic-test.personio.de"))
+            publicLocations(Location.IRELAND_AWS, Location.N_CALIFORNIA_AWS, Location.MUMBAI_AWS)
+            testFrequency(6.minutes)
+            advancedScheduling(
+                Timeframe(
+                    from = LocalTime.of(0, 1),
+                    to = LocalTime.of(23, 59),
+                    DayOfWeek.MONDAY,
+                    DayOfWeek.TUESDAY,
+                    DayOfWeek.FRIDAY
+                ),
+                timezone = ZoneId.of("Europe/Dublin")
+            )
+            retry(2, 600.milliseconds)
+            minFailureDuration(120.minutes)
+            minLocationFailed(2)
+            monitorName("Monitor for [Browser] Synthetic-Test-As-Code")
+            renotifyInterval(RenotifyInterval.HOURS_2)
+            monitorPriority(MonitorPriority.P3_MEDIUM)
+            useGlobalVariable("TEST_PASSWORD")
+            textVariable("TEXT_VARIABLE", "test")
+            numericPatternVariable(
+                name = "NUMERIC_PATTERN",
+                characterLength = 4,
+                prefix = "test"
+            )
+            alphabeticPatternVariable("ALPHABETIC_PATTERN", 5)
+            alphanumericPatternVariable("ALPHANUMERIC_PATTERN", 6)
+            datePatternVariable(
+                name = "DATE_PATTERN",
+                duration = (-1).days,
+                format = "MM-DD-YYYY"
+            )
+            timestampPatternVariable(
+                name = "TIMESTAMP_PATTERN",
+                duration = 10.seconds
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Why

To gradually migrate Browser tests to the Builder implementation introduced in #123.

## Scope

* Fixes some aspects of common `SyntheticTestBuilder`
* Adds the `SyntheticBrowserTestBuilder` class and corresponding DLS with a minimum configuration that passes the end-to-end test