### PR TITLE
Add tests for `baseUrl` and implement `publicLocation` deprecated method to comply to the existing contract

### DIFF
--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
@@ -25,7 +25,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 
 /**
- * An abstract class that wraps common methods for Synthetic Browser and API tests
+ * An abstract class that wraps common functions for Synthetic Browser and API tests
  */
 abstract class SyntheticTestBuilder(
     open val name: String,
@@ -101,6 +101,18 @@ abstract class SyntheticTestBuilder(
      */
     fun publicLocations(vararg locations: Location) {
         parameters.locations = locations.map { it.value }
+    }
+
+    /**
+     * Sets the locations for the synthetic test
+     * @param locationItems List of locations
+     */
+    @Deprecated(
+        message = "The function is deprecated. Please use `publicLocations` instead.",
+        replaceWith = ReplaceWith("publicLocations(*locationItems)")
+    )
+    fun publicLocation(vararg locationItems: Location) {
+        parameters.locations = locationItems.map { it.value }
     }
 
     /**

--- a/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
@@ -11,11 +11,12 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 class AssertionsBuilderTest {
+    private val assertionsBuilder = AssertionsBuilder()
+
     @Test
     fun `statusCode adds assertion that checks if the status code equals to the provided value`() {
-        val sut = AssertionsBuilder()
-        sut.statusCode(200)
-        val result = sut.build()
+        assertionsBuilder.statusCode(200)
+        val result = assertionsBuilder.build()
 
         assertEquals(
             SyntheticsAssertion(
@@ -30,9 +31,8 @@ class AssertionsBuilderTest {
 
     @Test
     fun `headerContains adds assertion that checks if the header contains the value`() {
-        val sut = AssertionsBuilder()
-        sut.headerContains("any_header", "any_value")
-        val result = sut.build()
+        assertionsBuilder.headerContains("any_header", "any_value")
+        val result = assertionsBuilder.build()
 
         assertEquals(
             SyntheticsAssertion(
@@ -48,9 +48,8 @@ class AssertionsBuilderTest {
 
     @Test
     fun `bodyContainsJsonPath adds assertion that validates the value stored in the given json path against the value provided`() {
-        val sut = AssertionsBuilder()
-        sut.bodyContainsJsonPath("any_json_path", "any_value")
-        val result = sut.build()
+        assertionsBuilder.bodyContainsJsonPath("any_json_path", "any_value")
+        val result = assertionsBuilder.build()
 
         assertEquals(
             SyntheticsAssertion(
@@ -71,9 +70,8 @@ class AssertionsBuilderTest {
 
     @Test
     fun `bodyContains adds assertion that checks if the body contains the given raw value`() {
-        val sut = AssertionsBuilder()
-        sut.bodyContains("any_value")
-        val result = sut.build()
+        assertionsBuilder.bodyContains("any_value")
+        val result = assertionsBuilder.build()
 
         assertEquals(
             SyntheticsAssertion(
@@ -88,12 +86,11 @@ class AssertionsBuilderTest {
 
     @Test
     fun `build returns list of assertions`() {
-        val sut = AssertionsBuilder()
-        sut.statusCode(200)
-        sut.headerContains("any_header", "any_value")
-        sut.bodyContainsJsonPath("any_json_path", "any_value")
-        sut.bodyContains("any_value")
-        val result = sut.build()
+        assertionsBuilder.statusCode(200)
+        assertionsBuilder.headerContains("any_header", "any_value")
+        assertionsBuilder.bodyContainsJsonPath("any_json_path", "any_value")
+        assertionsBuilder.bodyContains("any_value")
+        val result = assertionsBuilder.build()
 
         assertEquals(4, result.count())
     }

--- a/src/test/kotlin/com/personio/synthetics/builder/RequestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/RequestBuilderTest.kt
@@ -7,13 +7,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class RequestBuilderTest {
+    private var requestBuilder = RequestBuilder()
+
     @Test
     fun `headers appends given headers`() {
-        val sut = RequestBuilder()
-        sut.headers(
+        requestBuilder.headers(
             mapOf("any_header" to "any_value")
         )
-        val result = sut.build()
+        val result = requestBuilder.build()
 
         assertEquals(
             mapOf("any_header" to "any_value"),
@@ -23,9 +24,8 @@ class RequestBuilderTest {
 
     @Test
     fun `cookies add a Cookie header`() {
-        val sut = RequestBuilder()
-        sut.cookies("any_cookie")
-        val result = sut.build()
+        requestBuilder.cookies("any_cookie")
+        val result = requestBuilder.build()
 
         assertEquals(
             mapOf("Cookie" to "any_cookie"),
@@ -35,36 +35,32 @@ class RequestBuilderTest {
 
     @Test
     fun `url sets url`() {
-        val sut = RequestBuilder()
-        sut.url("any_url")
-        val result = sut.build()
+        requestBuilder.url("any_url")
+        val result = requestBuilder.build()
 
         assertEquals("any_url", result.url)
     }
 
     @Test
     fun `method sets http method`() {
-        val sut = RequestBuilder()
-        sut.method(RequestMethod.POST)
-        val result = sut.build()
+        requestBuilder.method(RequestMethod.POST)
+        val result = requestBuilder.build()
 
         assertEquals("POST", result.method)
     }
 
     @Test
     fun `body sets body`() {
-        val sut = RequestBuilder()
-        sut.body("any_body")
-        val result = sut.build()
+        requestBuilder.body("any_body")
+        val result = requestBuilder.build()
 
         assertEquals("any_body", result.body)
     }
 
     @Test
     fun `bodyType sets bodyType`() {
-        val sut = RequestBuilder()
-        sut.bodyType(SyntheticsTestRequestBodyType.APPLICATION_JSON)
-        val result = sut.build()
+        requestBuilder.bodyType(SyntheticsTestRequestBodyType.APPLICATION_JSON)
+        val result = requestBuilder.build()
 
         assertEquals(
             SyntheticsTestRequestBodyType.APPLICATION_JSON,
@@ -75,9 +71,8 @@ class RequestBuilderTest {
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `followRedirects sets followRedirects`(value: Boolean) {
-        val sut = RequestBuilder()
-        sut.followRedirects(value)
-        val result = sut.build()
+        requestBuilder.followRedirects(value)
+        val result = requestBuilder.build()
 
         assertEquals(
             value,
@@ -88,9 +83,8 @@ class RequestBuilderTest {
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `ignoreServerCertificateError sets allowInsecure`(value: Boolean) {
-        val sut = RequestBuilder()
-        sut.ignoreServerCertificateError(value)
-        val result = sut.build()
+        requestBuilder.ignoreServerCertificateError(value)
+        val result = requestBuilder.build()
 
         assertEquals(
             value,

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
@@ -1,0 +1,57 @@
+package com.personio.synthetics.builder
+
+import com.personio.synthetics.client.SyntheticsApiClient
+import com.personio.synthetics.config.getConfigFromFile
+import com.personio.synthetics.model.config.Location
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import java.net.URL
+
+class SyntheticBrowserTestBuilderTest {
+    private lateinit var testBuilder: SyntheticBrowserTestBuilder
+
+    @BeforeEach
+    fun prepareSut() {
+        val apiClientMock = Mockito.mock(SyntheticsApiClient::class.java)
+        testBuilder = SyntheticBrowserTestBuilder(
+            "any_name",
+            getConfigFromFile("config-unit-test.yaml").defaults,
+            apiClientMock
+        )
+    }
+
+    @Test
+    fun `baseUrl sets base URL`() {
+        testBuilder.baseUrl(URL("https://synthetic-test.personio.de"))
+        val result = testBuilder.build()
+
+        Assertions.assertEquals(
+            "https://synthetic-test.personio.de",
+            result.config.request.url
+        )
+    }
+
+    @Test
+    fun `publicLocations sets locations`() {
+        testBuilder.publicLocations(Location.TOKYO_AWS, Location.LONDON_AWS)
+        val result = testBuilder.build()
+
+        Assertions.assertEquals(
+            listOf(Location.TOKYO_AWS.value, Location.LONDON_AWS.value),
+            result.locations
+        )
+    }
+
+    @Test
+    fun `publicLocation sets locations`() {
+        testBuilder.publicLocation(Location.TOKYO_AWS, Location.LONDON_AWS)
+        val result = testBuilder.build()
+
+        Assertions.assertEquals(
+            listOf(Location.TOKYO_AWS.value, Location.LONDON_AWS.value),
+            result.locations
+        )
+    }
+}

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
@@ -25,12 +25,12 @@ import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 class SyntheticMultiStepApiTestBuilderTest {
-    private lateinit var sut: SyntheticMultiStepApiTestBuilder
+    private lateinit var testBuilder: SyntheticMultiStepApiTestBuilder
 
     @BeforeEach
     fun prepareSut() {
         val apiClientMock = Mockito.mock(SyntheticsApiClient::class.java)
-        sut = SyntheticMultiStepApiTestBuilder(
+        testBuilder = SyntheticMultiStepApiTestBuilder(
             "any_name",
             getConfigFromFile("config-unit-test.yaml").defaults,
             apiClientMock
@@ -39,8 +39,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `monitorName sets monitor name`() {
-        sut.monitorName("any_name")
-        val result = sut.build()
+        testBuilder.monitorName("any_name")
+        val result = testBuilder.build()
 
         assertEquals(
             "any_name",
@@ -50,8 +50,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `alertMessage appends formatted alert message`() {
-        sut.alertMessage("any_failure_message", "any_alert_medium")
-        val result = sut.build()
+        testBuilder.alertMessage("any_failure_message", "any_alert_medium")
+        val result = testBuilder.build()
 
         assertEquals(
             "any_alert_medium {{#is_alert}} any_failure_message {{/is_alert}} ",
@@ -61,8 +61,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `recoveryMessage appends formatted recovery message`() {
-        sut.recoveryMessage("any_recovery_message")
-        val result = sut.build()
+        testBuilder.recoveryMessage("any_recovery_message")
+        val result = testBuilder.build()
 
         assertEquals(
             " {{#is_recovery}} any_recovery_message {{/is_recovery}} ",
@@ -72,8 +72,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `tags sets tags`() {
-        sut.tags("any_tag1", "any_tag2")
-        val result = sut.build()
+        testBuilder.tags("any_tag1", "any_tag2")
+        val result = testBuilder.build()
 
         assertEquals(
             listOf("any_tag1", "any_tag2"),
@@ -83,8 +83,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `publicLocations sets locations`() {
-        sut.publicLocations(Location.FRANKFURT_AWS, Location.LONDON_AWS)
-        val result = sut.build()
+        testBuilder.publicLocations(Location.FRANKFURT_AWS, Location.LONDON_AWS)
+        val result = testBuilder.build()
 
         assertEquals(
             listOf(Location.FRANKFURT_AWS.value, Location.LONDON_AWS.value),
@@ -94,8 +94,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `testFrequency sets options tickEvery`() {
-        sut.testFrequency(5.minutes)
-        val result = sut.build()
+        testBuilder.testFrequency(5.minutes)
+        val result = testBuilder.build()
 
         assertEquals(
             5.minutes.inWholeSeconds,
@@ -106,20 +106,20 @@ class SyntheticMultiStepApiTestBuilderTest {
     @Test
     fun `testFrequency throws IllegalArgumentException when frequency is less than 30 seconds`() {
         assertThrows<IllegalArgumentException> {
-            sut.testFrequency(29.seconds)
+            testBuilder.testFrequency(29.seconds)
         }
     }
 
     @Test
     fun `testFrequency throws IllegalArgumentException when frequency is more than 7 days`() {
         assertThrows<IllegalArgumentException> {
-            sut.testFrequency((604800 + 1).seconds) // 7 days + 1 second
+            testBuilder.testFrequency((604800 + 1).seconds) // 7 days + 1 second
         }
     }
 
     @Test
     fun `advancedScheduling sets the advanced scheduling configuration`() {
-        sut.advancedScheduling(
+        testBuilder.advancedScheduling(
             Timeframe(
                 from = LocalTime.of(0, 1),
                 to = LocalTime.of(23, 59),
@@ -128,7 +128,7 @@ class SyntheticMultiStepApiTestBuilderTest {
             ),
             timezone = ZoneId.of("Europe/Dublin")
         )
-        val result = sut.build()
+        val result = testBuilder.build()
 
         assertEquals(1, result.options.scheduling.timeframes[0].day)
         assertEquals("00:01", result.options.scheduling.timeframes[0].from)
@@ -141,14 +141,14 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `advancedScheduling function sets the advanced scheduling with default timezone in the test config`() {
-        sut.advancedScheduling(
+        testBuilder.advancedScheduling(
             Timeframe(
                 from = LocalTime.of(0, 1),
                 to = LocalTime.of(23, 59),
                 DayOfWeek.MONDAY
             )
         )
-        val result = sut.build()
+        val result = testBuilder.build()
 
         assertNotNull(result.options.scheduling.timezone)
         assertTrue(result.options.scheduling.timezone.isNotEmpty())
@@ -156,8 +156,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `uuidVariable adds variable of UUID pattern`() {
-        sut.uuidVariable("any_name")
-        val result = sut.build()
+        testBuilder.uuidVariable("any_name")
+        val result = testBuilder.build()
 
         assertTrue(
             result.config.configVariables.contains(
@@ -172,8 +172,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `timestampPatternVariable adds variable of timestamp pattern`() {
-        sut.timestampPatternVariable("any_name", 5.minutes, "prefix-", "-suffix")
-        val result = sut.build()
+        testBuilder.timestampPatternVariable("any_name", 5.minutes, "prefix-", "-suffix")
+        val result = testBuilder.build()
 
         assertTrue(
             result.config.configVariables.contains(
@@ -188,8 +188,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `datePatternVariable adds variable of timestamp pattern`() {
-        sut.datePatternVariable("any_name", 5.days, "YYYY-MM-DD", "prefix-", "-suffix")
-        val result = sut.build()
+        testBuilder.datePatternVariable("any_name", 5.days, "YYYY-MM-DD", "prefix-", "-suffix")
+        val result = testBuilder.build()
 
         assertTrue(
             result.config.configVariables.contains(
@@ -204,8 +204,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `alphanumericPatternVariable adds variable of timestamp pattern`() {
-        sut.alphanumericPatternVariable("any_name", 10, "prefix-", "-suffix")
-        val result = sut.build()
+        testBuilder.alphanumericPatternVariable("any_name", 10, "prefix-", "-suffix")
+        val result = testBuilder.build()
 
         assertTrue(
             result.config.configVariables.contains(
@@ -220,8 +220,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `alphabeticPatternVariable adds variable of timestamp pattern`() {
-        sut.alphabeticPatternVariable("any_name", 10, "prefix-", "-suffix")
-        val result = sut.build()
+        testBuilder.alphabeticPatternVariable("any_name", 10, "prefix-", "-suffix")
+        val result = testBuilder.build()
 
         assertTrue(
             result.config.configVariables.contains(
@@ -236,8 +236,8 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `numericPatternVariable adds variable of timestamp pattern`() {
-        sut.numericPatternVariable("any_name", 10, "prefix-", "-suffix")
-        val result = sut.build()
+        testBuilder.numericPatternVariable("any_name", 10, "prefix-", "-suffix")
+        val result = testBuilder.build()
 
         assertTrue(
             result.config.configVariables.contains(
@@ -252,13 +252,13 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `steps sets provided list of steps`() {
-        sut.steps(
+        testBuilder.steps(
             listOf(
                 SyntheticsAPIStep(),
                 SyntheticsAPIStep()
             )
         )
-        val result = sut.build()
+        val result = testBuilder.build()
 
         assertEquals(
             2,
@@ -271,8 +271,8 @@ class SyntheticMultiStepApiTestBuilderTest {
         val stepsBuilderMock = Mockito.mock(StepsBuilder::class.java)
         whenever(stepsBuilderMock.build())
             .thenReturn(listOf(SyntheticsAPIStep(), SyntheticsAPIStep()))
-        sut.steps(stepsBuilderMock) {}
-        val result = sut.build()
+        testBuilder.steps(stepsBuilderMock) {}
+        val result = testBuilder.build()
 
         assertEquals(
             2,
@@ -282,10 +282,10 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `env adds env tag`() {
-        sut.env("env1")
-        sut.env("env2")
+        testBuilder.env("env1")
+        testBuilder.env("env2")
 
-        val result = sut.build()
+        val result = testBuilder.build()
 
         assertTrue(result.tags.contains("env:env1"))
         assertTrue(result.tags.contains("env:env2"))
@@ -293,10 +293,10 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `team adds team tag`() {
-        sut.team("team-one")
-        sut.team("team-two")
+        testBuilder.team("team-one")
+        testBuilder.team("team-two")
 
-        val result = sut.build()
+        val result = testBuilder.build()
 
         assertTrue(result.tags.contains("team:team-one"))
         assertTrue(result.tags.contains("team:team-two"))
@@ -304,14 +304,14 @@ class SyntheticMultiStepApiTestBuilderTest {
 
     @Test
     fun `status is set to PAUSED by default`() {
-        val result = sut.build()
+        val result = testBuilder.build()
         assertEquals(SyntheticsTestPauseStatus.PAUSED, result.status)
     }
 
     @Test
     fun `status sets status of a test`() {
-        sut.status(SyntheticsTestPauseStatus.LIVE)
-        val result = sut.build()
+        testBuilder.status(SyntheticsTestPauseStatus.LIVE)
+        val result = testBuilder.build()
 
         assertEquals(SyntheticsTestPauseStatus.LIVE, result.status)
     }

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
@@ -23,7 +23,7 @@ import org.mockito.kotlin.whenever
 class StepBuilderTest {
     @Test
     fun `extract sets the extracted values properly`() {
-        val sut = StepBuilder(
+        val stepBuilder = StepBuilder(
             "any_name",
             makeRequestBuilderHappyPathMock(),
             makeAssertionBuilderMock(),
@@ -31,24 +31,24 @@ class StepBuilderTest {
                 SyntheticsParsingOptions()
             )
         )
-        sut.request { }
-        sut.extract("any_variable_name") {}
-        val result = sut.build()
+        stepBuilder.request { }
+        stepBuilder.extract("any_variable_name") {}
+        val result = stepBuilder.build()
 
         assertEquals(1, result.extractedValues.count())
     }
 
     @Test
     fun `extract sets the extracted values to null when no parsing options provided`() {
-        val sut = StepBuilder(
+        val stepBuilder = StepBuilder(
             "any_name",
             makeRequestBuilderHappyPathMock(),
             makeAssertionBuilderMock(),
             makeParsingOptionsBuilderMock()
         )
-        sut.request { }
-        sut.extract("any_variable_name") {}
-        val result = sut.build()
+        stepBuilder.request { }
+        stepBuilder.extract("any_variable_name") {}
+        val result = stepBuilder.build()
 
         assertNull(result.extractedValues)
     }
@@ -56,10 +56,10 @@ class StepBuilderTest {
     @Test
     fun `request sets the request in SyntheticsAPIStep`() {
         val requestBuilderMock = makeRequestBuilderHappyPathMock()
-        val sut = StepBuilder("any_name", requestBuilderMock)
-        sut.request { }
+        val stepBuilder = StepBuilder("any_name", requestBuilderMock)
+        stepBuilder.request { }
 
-        val result = sut.build()
+        val result = stepBuilder.build()
         verify(requestBuilderMock, times(1)).build()
         assertNotNull(result.request)
     }
@@ -69,10 +69,10 @@ class StepBuilderTest {
         val assertionsMock = makeAssertionBuilderMock(
             listOf(SyntheticsAssertion(), SyntheticsAssertion())
         )
-        val sut = StepBuilder("any_name", RequestBuilder(), assertionsMock)
-        sut.assertions { }
-        sut.request { }
-        val result = sut.build()
+        val stepBuilder = StepBuilder("any_name", RequestBuilder(), assertionsMock)
+        stepBuilder.assertions { }
+        stepBuilder.request { }
+        val result = stepBuilder.build()
 
         verify(assertionsMock, times(1)).build()
         assertEquals(2, result.assertions.count())
@@ -80,18 +80,18 @@ class StepBuilderTest {
 
     @Test
     fun `build sets HTTP step subtype`() {
-        val sut = StepBuilder("any_name", RequestBuilder())
-        sut.request { }
-        val result = sut.build()
+        val stepBuilder = StepBuilder("any_name", RequestBuilder())
+        stepBuilder.request { }
+        val result = stepBuilder.build()
 
         assertEquals(SyntheticsAPIStepSubtype.HTTP, result.subtype)
     }
 
     @Test
     fun `build sets step name properly`() {
-        val sut = StepBuilder("any_name", RequestBuilder())
-        sut.request { }
-        val result = sut.build()
+        val stepBuilder = StepBuilder("any_name", RequestBuilder())
+        stepBuilder.request { }
+        val result = stepBuilder.build()
 
         assertEquals("any_name", result.name)
     }
@@ -99,10 +99,10 @@ class StepBuilderTest {
     @Test
     fun `build sets empty assertions by default`() {
         val assertionsMock = makeAssertionBuilderMock()
-        val sut = StepBuilder("any_name", RequestBuilder(), assertionsMock)
-        sut.assertions { }
-        sut.request { }
-        val result = sut.build()
+        val stepBuilder = StepBuilder("any_name", RequestBuilder(), assertionsMock)
+        stepBuilder.assertions { }
+        stepBuilder.request { }
+        val result = stepBuilder.build()
 
         verify(assertionsMock, times(1)).build()
         assertTrue(result.assertions.isEmpty())
@@ -113,20 +113,20 @@ class StepBuilderTest {
         val requestBuilderMock = Mockito.mock(RequestBuilder::class.java)
         whenever(requestBuilderMock.build())
             .thenReturn(null)
-        val sut = StepBuilder("any_name", requestBuilderMock)
+        val stepBuilder = StepBuilder("any_name", requestBuilderMock)
 
         assertThrows<IllegalStateException> {
-            sut.build()
+            stepBuilder.build()
         }
     }
 
     @Test
     fun `build sets isCritical to null when allowFailure is false`() {
-        val sut = StepBuilder("any_name", makeRequestBuilderHappyPathMock())
-        sut.allowFailure = false
-        sut.isCritical = true
-        sut.request { }
-        val result = sut.build()
+        val stepBuilder = StepBuilder("any_name", makeRequestBuilderHappyPathMock())
+        stepBuilder.allowFailure = false
+        stepBuilder.isCritical = true
+        stepBuilder.request { }
+        val result = stepBuilder.build()
 
         assertNull(result.isCritical)
     }
@@ -134,11 +134,11 @@ class StepBuilderTest {
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `build sets isCritical to the provided value when allowFailure is true`(isCritical: Boolean) {
-        val sut = StepBuilder("any_name", makeRequestBuilderHappyPathMock())
-        sut.allowFailure = true
-        sut.isCritical = isCritical
-        sut.request { }
-        val result = sut.build()
+        val stepBuilder = StepBuilder("any_name", makeRequestBuilderHappyPathMock())
+        stepBuilder.allowFailure = true
+        stepBuilder.isCritical = isCritical
+        stepBuilder.request { }
+        val result = stepBuilder.build()
 
         assertEquals(isCritical, result.isCritical)
     }

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepsBuilderTest.kt
@@ -9,10 +9,10 @@ import org.mockito.kotlin.whenever
 class StepsBuilderTest {
     @Test
     fun `step adds a step to the list`() {
-        val sut = StepsBuilder()
-        sut.step("any_name", makeStepBuilderMock(SyntheticsAPIStep())) {}
-        sut.step("any_name", makeStepBuilderMock(SyntheticsAPIStep())) {}
-        val result = sut.build()
+        val stepsBuilder = StepsBuilder()
+        stepsBuilder.step("any_name", makeStepBuilderMock(SyntheticsAPIStep())) {}
+        stepsBuilder.step("any_name", makeStepBuilderMock(SyntheticsAPIStep())) {}
+        val result = stepsBuilder.build()
 
         assertEquals(2, result.count())
     }

--- a/src/test/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilderTest.kt
@@ -11,40 +11,38 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 
 class ParsingOptionsBuilderTest {
+    private val parsingOptionsBuilder = ParsingOptionsBuilder()
+
     @Test
     fun `variable sets variable name`() {
-        val sut = ParsingOptionsBuilder()
-        sut.bodyJsonPath("any")
-        sut.variable("any_name")
+        parsingOptionsBuilder.bodyJsonPath("any")
+        parsingOptionsBuilder.variable("any_name")
 
-        assertEquals("any_name", sut.build()!!.name)
+        assertEquals("any_name", parsingOptionsBuilder.build()!!.name)
     }
 
     @Test
     fun `build throws IllegalArgumentException when no parsing options set`() {
-        val sut = ParsingOptionsBuilder()
-        sut.variable("any_name")
+        val parsingOptionsBuilder = ParsingOptionsBuilder()
+        parsingOptionsBuilder.variable("any_name")
 
         assertThrows<IllegalStateException> {
-            sut.build()
+            parsingOptionsBuilder.build()
         }
     }
 
     @Test
     fun `build throws IllegalArgumentException when no variable name set`() {
-        val sut = ParsingOptionsBuilder()
-
         assertThrows<IllegalStateException> {
-            sut.build()
+            parsingOptionsBuilder.build()
         }
     }
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `bodyJsonPath returns parsing options with JSON_PATH parser type and HTTP_BODY type`(secure: Boolean) {
-        val sut = ParsingOptionsBuilder()
-        sut.variable("any_name")
-        sut.bodyJsonPath("any_json_path", secure)
+        parsingOptionsBuilder.variable("any_name")
+        parsingOptionsBuilder.bodyJsonPath("any_json_path", secure)
 
         assertEquals(
             SyntheticsParsingOptions()
@@ -56,16 +54,15 @@ class ParsingOptionsBuilderTest {
                 )
                 .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_BODY)
                 .secure(secure),
-            sut.build()
+            parsingOptionsBuilder.build()
         )
     }
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `bodyRegex returns parsing options with REGEX parser type and HTTP_BODY type`(secure: Boolean) {
-        val sut = ParsingOptionsBuilder()
-        sut.variable("any_name")
-        sut.bodyRegex("any_regex", secure)
+        parsingOptionsBuilder.variable("any_name")
+        parsingOptionsBuilder.bodyRegex("any_regex", secure)
 
         assertEquals(
             SyntheticsParsingOptions()
@@ -77,16 +74,15 @@ class ParsingOptionsBuilderTest {
                 )
                 .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_BODY)
                 .secure(secure),
-            sut.build()
+            parsingOptionsBuilder.build()
         )
     }
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `header returns parsing options with RAW parser type and HTTP_HEADER type`(secure: Boolean) {
-        val sut = ParsingOptionsBuilder()
-        sut.variable("any_name")
-        sut.header("any_header_name", secure)
+        parsingOptionsBuilder.variable("any_name")
+        parsingOptionsBuilder.header("any_header_name", secure)
 
         assertEquals(
             SyntheticsParsingOptions()
@@ -98,16 +94,15 @@ class ParsingOptionsBuilderTest {
                 )
                 .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_HEADER)
                 .secure(secure),
-            sut.build()
+            parsingOptionsBuilder.build()
         )
     }
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
     fun `headerRegex returns parsing options with REGEX parser type and HTTP_HEADER type`(secure: Boolean) {
-        val sut = ParsingOptionsBuilder()
-        sut.variable("any_name")
-        sut.headerRegex("any_header_name", "any_regex", secure)
+        parsingOptionsBuilder.variable("any_name")
+        parsingOptionsBuilder.headerRegex("any_header_name", "any_regex", secure)
 
         assertEquals(
             SyntheticsParsingOptions()
@@ -120,7 +115,7 @@ class ParsingOptionsBuilderTest {
                 )
                 .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_HEADER)
                 .secure(secure),
-            sut.build()
+            parsingOptionsBuilder.build()
         )
     }
 }


### PR DESCRIPTION
## Scope

* Implements the `publicLocation` method as already deprecated to comply with the existing contract
* Adds missing test for `baseUrl`