### PR TITLE
Implement `testFrequency` for browser tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add handy `env()` and `team()` functions for adding corresponding Datadog `key:value` tags ([#126](https://github.com/personio/datadog-synthetic-test-support/pull/126))
 - Add minimum working implementation of a refactored browser test support ([#129](https://github.com/personio/datadog-synthetic-test-support/pull/129))
 - Add `status()` function to set the SyntheticTestPauseStatus property ([#127](https://github.com/personio/datadog-synthetic-test-support/pull/127))
+- Add `testFrequency()` function to set the test execution frequency in browser tests ([#137](https://github.com/personio/datadog-synthetic-test-support/pull/137))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilder.kt
@@ -10,6 +10,9 @@ import com.datadog.api.client.v1.model.SyntheticsTestRequest
 import com.personio.synthetics.client.SyntheticsApiClient
 import com.personio.synthetics.config.Defaults
 import java.net.URL
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * A builder for creating SyntheticsBrowserTest instances
@@ -47,6 +50,18 @@ class SyntheticBrowserTestBuilder(
                 .method("GET")
                 .url(url.toString())
         )
+    }
+
+    /**
+     * Sets the test execution frequency for the synthetic browser test
+     * @param frequency The frequency of the test
+     * Allowed test frequency is between 5 minutes and 7 days
+     */
+    override fun testFrequency(frequency: Duration) {
+        require(frequency in 5.minutes..7.days) {
+            "Frequency should be between 5 minutes and 7 days."
+        }
+        options.tickEvery = frequency.inWholeSeconds
     }
 
     override fun addLocalVariable(name: String, pattern: String) {

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
@@ -116,11 +116,11 @@ abstract class SyntheticTestBuilder(
     }
 
     /**
-     * Sets the test frequency for the synthetic test
+     * Sets the test execution frequency for the synthetic test
      * @param frequency The frequency of the test
      * Allowed test frequency is between 30 seconds and 7 days
      */
-    fun testFrequency(frequency: Duration) {
+    open fun testFrequency(frequency: Duration) {
         require(frequency in 30.seconds..7.days) {
             "Frequency should be between 30 seconds and 1 week."
         }

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
@@ -3,11 +3,14 @@ package com.personio.synthetics.builder
 import com.personio.synthetics.client.SyntheticsApiClient
 import com.personio.synthetics.config.getConfigFromFile
 import com.personio.synthetics.model.config.Location
-import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito
 import java.net.URL
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.minutes
 
 class SyntheticBrowserTestBuilderTest {
     private lateinit var testBuilder: SyntheticBrowserTestBuilder
@@ -27,7 +30,7 @@ class SyntheticBrowserTestBuilderTest {
         testBuilder.baseUrl(URL("https://synthetic-test.personio.de"))
         val result = testBuilder.build()
 
-        Assertions.assertEquals(
+        assertEquals(
             "https://synthetic-test.personio.de",
             result.config.request.url
         )
@@ -38,7 +41,7 @@ class SyntheticBrowserTestBuilderTest {
         testBuilder.publicLocations(Location.TOKYO_AWS, Location.LONDON_AWS)
         val result = testBuilder.build()
 
-        Assertions.assertEquals(
+        assertEquals(
             listOf(Location.TOKYO_AWS.value, Location.LONDON_AWS.value),
             result.locations
         )
@@ -49,9 +52,34 @@ class SyntheticBrowserTestBuilderTest {
         testBuilder.publicLocation(Location.TOKYO_AWS, Location.LONDON_AWS)
         val result = testBuilder.build()
 
-        Assertions.assertEquals(
+        assertEquals(
             listOf(Location.TOKYO_AWS.value, Location.LONDON_AWS.value),
             result.locations
+        )
+    }
+
+    @Test
+    fun `testFrequency throws IllegalArgumentException if frequency is less than 5 minutes`() {
+        assertThrows<IllegalArgumentException> {
+            testBuilder.testFrequency(4.minutes)
+        }
+    }
+
+    @Test
+    fun `testFrequency throws IllegalArgumentException if frequency is more than 7 days`() {
+        assertThrows<IllegalArgumentException> {
+            testBuilder.testFrequency(8.days)
+        }
+    }
+
+    @Test
+    fun `testFrequency sets frequency in whole seconds`() {
+        testBuilder.testFrequency(7.days)
+        val result = testBuilder.build()
+
+        assertEquals(
+            7.days.inWholeSeconds,
+            result.options.tickEvery
         )
     }
 }


### PR DESCRIPTION
## Why

To put _opinionated_ difference in constraints in browser and multi-step API tests.