### PR TITLE
Implement backward-compatible `tags` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `status()` function to set the SyntheticTestPauseStatus property ([#127](https://github.com/personio/datadog-synthetic-test-support/pull/127))
 - Add `testFrequency()` function to set the test execution frequency in browser tests ([#137](https://github.com/personio/datadog-synthetic-test-support/pull/137))
 - Add `browsersAndDevices()` function to set the device ids for browser tests ([#139](https://github.com/personio/datadog-synthetic-test-support/pull/139))
+- Add `tags()` function to set the tags for browser tests ([#138](https://github.com/personio/datadog-synthetic-test-support/pull/138))
 
 ### Bug fixes
 - Fix scroll parameters check to include values from -9999 to 9999 ([#140](https://github.com/personio/datadog-synthetic-test-support/pull/140))

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
@@ -96,6 +96,18 @@ abstract class SyntheticTestBuilder(
     }
 
     /**
+     * Adds the tags for the synthetic test
+     * @param tags List of tags
+     */
+    @Deprecated(
+        message = "The function is deprecated. Please use `tags` instead.",
+        replaceWith = ReplaceWith("tags(*tags.toTypedArray())")
+    )
+    fun tags(tags: List<String>) {
+        parameters.tags.addAll(tags)
+    }
+
+    /**
      * Sets the locations for the synthetic test
      * @param locations List of locations
      */

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
@@ -82,6 +82,17 @@ class SyntheticMultiStepApiTestBuilderTest {
     }
 
     @Test
+    fun `tags (list) sets tags`() {
+        testBuilder.tags(listOf("any_tag1", "any_tag2"))
+        val result = testBuilder.build()
+
+        assertEquals(
+            listOf("any_tag1", "any_tag2"),
+            result.tags
+        )
+    }
+
+    @Test
     fun `publicLocations sets locations`() {
         testBuilder.publicLocations(Location.FRANKFURT_AWS, Location.LONDON_AWS)
         val result = testBuilder.build()


### PR DESCRIPTION
## Why

To support existing API for Browser tests.