### PR TITLE
Implement `browsersAndDevices` function for browser tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add minimum working implementation of a refactored browser test support ([#129](https://github.com/personio/datadog-synthetic-test-support/pull/129))
 - Add `status()` function to set the SyntheticTestPauseStatus property ([#127](https://github.com/personio/datadog-synthetic-test-support/pull/127))
 - Add `testFrequency()` function to set the test execution frequency in browser tests ([#137](https://github.com/personio/datadog-synthetic-test-support/pull/137))
+- Add `browsersAndDevices()` function to set the device ids for browser tests ([#139](https://github.com/personio/datadog-synthetic-test-support/pull/139))
 
 ### Bug fixes
 - Fix scroll parameters check to include values from -9999 to 9999 ([#140](https://github.com/personio/datadog-synthetic-test-support/pull/140))

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilder.kt
@@ -5,6 +5,7 @@ import com.datadog.api.client.v1.model.SyntheticsBrowserTestConfig
 import com.datadog.api.client.v1.model.SyntheticsBrowserTestType
 import com.datadog.api.client.v1.model.SyntheticsBrowserVariable
 import com.datadog.api.client.v1.model.SyntheticsBrowserVariableType
+import com.datadog.api.client.v1.model.SyntheticsDeviceID
 import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
 import com.datadog.api.client.v1.model.SyntheticsTestRequest
 import com.personio.synthetics.client.SyntheticsApiClient
@@ -62,6 +63,26 @@ class SyntheticBrowserTestBuilder(
             "Frequency should be between 5 minutes and 7 days."
         }
         options.tickEvery = frequency.inWholeSeconds
+    }
+
+    /**
+     * Sets the browsers and devices for the synthetic browser test
+     * @param deviceIds Pass comma separated browsers and devices to the test config derived from SyntheticsDeviceID class
+     */
+    fun browsersAndDevices(vararg deviceIds: SyntheticsDeviceID) {
+        options.deviceIds = deviceIds.map { it }
+    }
+
+    /**
+     * Sets the browsers and devices for the synthetic browser test
+     * @param deviceIds Pass comma separated browsers and devices to the test config derived from SyntheticsDeviceID class
+     */
+    @Deprecated(
+        message = "The function is deprecated. Please use `browsersAndDevices` instead.",
+        replaceWith = ReplaceWith("browsersAndDevices(*deviceIds)")
+    )
+    fun browserAndDevice(vararg deviceIds: SyntheticsDeviceID) {
+        options.deviceIds = deviceIds.map { it }
     }
 
     override fun addLocalVariable(name: String, pattern: String) {

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
@@ -1,5 +1,6 @@
 package com.personio.synthetics.builder
 
+import com.datadog.api.client.v1.model.SyntheticsDeviceID
 import com.personio.synthetics.client.SyntheticsApiClient
 import com.personio.synthetics.config.getConfigFromFile
 import com.personio.synthetics.model.config.Location
@@ -80,6 +81,28 @@ class SyntheticBrowserTestBuilderTest {
         assertEquals(
             7.days.inWholeSeconds,
             result.options.tickEvery
+        )
+    }
+
+    @Test
+    fun `browserAndDevice sets deviceIds`() {
+        testBuilder.browserAndDevice(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET)
+        val result = testBuilder.build()
+
+        assertEquals(
+            result.options.deviceIds,
+            listOf(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET)
+        )
+    }
+
+    @Test
+    fun `browsersAndDevices sets deviceIds`() {
+        testBuilder.browsersAndDevices(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET)
+        val result = testBuilder.build()
+
+        assertEquals(
+            result.options.deviceIds,
+            listOf(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET)
         )
     }
 }

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EBrowserTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EBrowserTest.kt
@@ -1,5 +1,6 @@
 package com.personio.synthetics.e2e
 
+import com.datadog.api.client.v1.model.SyntheticsDeviceID
 import com.personio.synthetics.dsl.syntheticBrowserTest
 import com.personio.synthetics.model.config.Location
 import com.personio.synthetics.model.config.MonitorPriority
@@ -24,6 +25,7 @@ class E2EBrowserTest {
             env("qa")
             tags("synthetics-api")
             baseUrl(URL("https://synthetic-test.personio.de"))
+            browsersAndDevices(SyntheticsDeviceID.CHROME_MOBILE_SMALL, SyntheticsDeviceID.FIREFOX_LAPTOP_LARGE)
             publicLocations(Location.IRELAND_AWS, Location.N_CALIFORNIA_AWS, Location.MUMBAI_AWS)
             testFrequency(6.minutes)
             advancedScheduling(


### PR DESCRIPTION
## Why

To support setting browsers and devices in synthetic browser tests.