### PR TITLE
Fix scroll parameters check to include values from -9999 to 9999

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `testFrequency()` function to set the test execution frequency in browser tests ([#137](https://github.com/personio/datadog-synthetic-test-support/pull/137))
 
 ### Bug fixes
+- Fix scroll parameters check to include values from -9999 to 9999 ([#140](https://github.com/personio/datadog-synthetic-test-support/pull/140))
 
 ### Dependencies
 

--- a/src/main/kotlin/com/personio/synthetics/step/ui/SpecialActionsStep.kt
+++ b/src/main/kotlin/com/personio/synthetics/step/ui/SpecialActionsStep.kt
@@ -44,8 +44,8 @@ fun BrowserTest.scrollStep(stepName: String, f: SpecialActionsStep.() -> Unit): 
         f()
         with(params as SpecialActionsParams) {
             check(
-                (x in 0..9999 && y in 0..9999) || (element != null)
-            ) { "Either set x,y coordinates within(0,9999) pixels or target element for step:'$stepName'." }
+                (x in -9999..9999 && y in -9999..9999) || (element != null)
+            ) { "Either set x,y coordinates within(-9999,9999) pixels or target element for step:'$stepName'." }
         }
     }
 

--- a/src/test/kotlin/com/personio/synthetics/step/ui/SpecialActionsStepTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/step/ui/SpecialActionsStepTest.kt
@@ -143,20 +143,20 @@ internal class SpecialActionsStepTest {
     }
 
     @Test
-    fun `scrollStep throws exception for x coordinate less than 0 pixels`() {
+    fun `scrollStep throws exception for x coordinate less than -9999 pixels`() {
         assertThrows<IllegalStateException> {
             browserTest.scrollStep("Step") {
                 verticalScroll(1)
-                horizontalScroll(-1)
+                horizontalScroll(-10000)
             }
         }
     }
 
     @Test
-    fun `scrollStep throws exception for y coordinate less than 0 pixels`() {
+    fun `scrollStep throws exception for y coordinate less than -9999 pixels`() {
         assertThrows<IllegalStateException> {
             browserTest.scrollStep("Step") {
-                verticalScroll(-1)
+                verticalScroll(-10000)
                 horizontalScroll(1)
             }
         }


### PR DESCRIPTION
Problem: Currently there is no possibility to set vertical and/or horizontal scroll parameter to any value below 0, despite on UI it's possible.
Solution: Update scroll parameters check to include values from -9999 to 9999