### PR TITLE
Prepare to release 2.2.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,15 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
+
+### Bug fixes
+
+### Dependencies
+
+## [2.2.0] - 2023-10-20
+### New features & improvements
 - Add handy `env()` and `team()` functions for adding corresponding Datadog `key:value` tags ([#126](https://github.com/personio/datadog-synthetic-test-support/pull/126))
-- Add minimum working implementation of a refactored browser test support ([#129](https://github.com/personio/datadog-synthetic-test-support/pull/129))
+- Add minimum working implementation of a refactored browser test support ([#129](https://github.com/personio/datadog-synthetic-test-support/pull/129), [#141](https://github.com/personio/datadog-synthetic-test-support/pull/141))
 - Add `status()` function to set the SyntheticTestPauseStatus property ([#127](https://github.com/personio/datadog-synthetic-test-support/pull/127))
 - Add `testFrequency()` function to set the test execution frequency in browser tests ([#137](https://github.com/personio/datadog-synthetic-test-support/pull/137))
 - Add `browsersAndDevices()` function to set the device ids for browser tests ([#139](https://github.com/personio/datadog-synthetic-test-support/pull/139))


### PR DESCRIPTION
Problem: In order to prepare to the new release Changelog file should contain a new release section.
Solution: Add a new release section 2.2.0 to the Changelog