### PR TITLE
Fix tests: swap expected and actual values in assertions

### DIFF
--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
@@ -90,8 +90,8 @@ class SyntheticBrowserTestBuilderTest {
         val result = testBuilder.build()
 
         assertEquals(
-            result.options.deviceIds,
-            listOf(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET)
+            listOf(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET),
+            result.options.deviceIds
         )
     }
 
@@ -101,8 +101,8 @@ class SyntheticBrowserTestBuilderTest {
         val result = testBuilder.build()
 
         assertEquals(
-            result.options.deviceIds,
-            listOf(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET)
+            listOf(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET),
+            result.options.deviceIds
         )
     }
 }


### PR DESCRIPTION
## Scope

This PR fixes the order of expected and actual values in some tests.