### PR TITLE
Make the test status not set by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
+- Make the test `status` not set by default ([#14](https://github.com/personio/datadog-synthetic-test-support/pull/144))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilder.kt
@@ -6,7 +6,6 @@ import com.datadog.api.client.v1.model.SyntheticsBrowserTestType
 import com.datadog.api.client.v1.model.SyntheticsBrowserVariable
 import com.datadog.api.client.v1.model.SyntheticsBrowserVariableType
 import com.datadog.api.client.v1.model.SyntheticsDeviceID
-import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
 import com.datadog.api.client.v1.model.SyntheticsTestRequest
 import com.personio.synthetics.client.SyntheticsApiClient
 import com.personio.synthetics.config.Defaults
@@ -31,8 +30,8 @@ class SyntheticBrowserTestBuilder(
      * Builds a synthetic browser test
      * @return SyntheticsBrowserTest object that contains a browser test
      */
-    fun build(): SyntheticsBrowserTest =
-        SyntheticsBrowserTest(
+    fun build(): SyntheticsBrowserTest {
+        val test = SyntheticsBrowserTest(
             config,
             parameters.locations,
             parameters.message,
@@ -41,7 +40,13 @@ class SyntheticBrowserTestBuilder(
             SyntheticsBrowserTestType.BROWSER
         )
             .tags(parameters.tags)
-            .status(SyntheticsTestPauseStatus.PAUSED)
+
+        status?.let {
+            test.status(it)
+        }
+
+        return test
+    }
 
     /**
      * Sets the base url for the synthetic browser test

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilder.kt
@@ -25,8 +25,8 @@ class SyntheticMultiStepApiTestBuilder(
      * Builds a synthetic API test
      * @return SyntheticsAPITest object that contains an API test
      */
-    fun build(): SyntheticsAPITest =
-        SyntheticsAPITest(
+    fun build(): SyntheticsAPITest {
+        val test = SyntheticsAPITest(
             config,
             parameters.locations,
             parameters.message,
@@ -35,8 +35,14 @@ class SyntheticMultiStepApiTestBuilder(
             SyntheticsAPITestType.API
         )
             .tags(parameters.tags)
-            .status(status)
             .subtype(SyntheticsTestDetailsSubType.MULTI)
+
+        status?.let {
+            test.status(it)
+        }
+
+        return test
+    }
 
     /**
      * Specifies API steps for a test using a DSL

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
@@ -34,7 +34,7 @@ abstract class SyntheticTestBuilder(
 ) {
     protected var parameters: SyntheticTestParameters
     protected var options: SyntheticsTestOptions
-    protected var status: SyntheticsTestPauseStatus = SyntheticsTestPauseStatus.PAUSED
+    protected var status: SyntheticsTestPauseStatus? = null
 
     init {
         parameters = SyntheticTestParameters(
@@ -320,6 +320,10 @@ abstract class SyntheticTestBuilder(
         tags("team:$teamName")
     }
 
+    /**
+     * Sets a synthetic test status
+     * @param status Synthetic test status
+     */
     fun status(status: SyntheticsTestPauseStatus) {
         this.status = status
     }

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticBrowserTestBuilderTest.kt
@@ -1,10 +1,12 @@
 package com.personio.synthetics.builder
 
 import com.datadog.api.client.v1.model.SyntheticsDeviceID
+import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
 import com.personio.synthetics.client.SyntheticsApiClient
 import com.personio.synthetics.config.getConfigFromFile
 import com.personio.synthetics.model.config.Location
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -104,5 +106,19 @@ class SyntheticBrowserTestBuilderTest {
             listOf(SyntheticsDeviceID.CHROME_TABLET, SyntheticsDeviceID.FIREFOX_TABLET),
             result.options.deviceIds
         )
+    }
+
+    @Test
+    fun `status sets status of a test`() {
+        testBuilder.status(SyntheticsTestPauseStatus.LIVE)
+        val result = testBuilder.build()
+
+        assertEquals(SyntheticsTestPauseStatus.LIVE, result.status)
+    }
+
+    @Test
+    fun `build specifies no status by default`() {
+        val result = testBuilder.build()
+        assertNull(result.status)
     }
 }

--- a/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/SyntheticMultiStepApiTestBuilderTest.kt
@@ -11,6 +11,7 @@ import com.personio.synthetics.model.config.Location
 import com.personio.synthetics.model.config.Timeframe
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -314,16 +315,16 @@ class SyntheticMultiStepApiTestBuilderTest {
     }
 
     @Test
-    fun `status is set to PAUSED by default`() {
-        val result = testBuilder.build()
-        assertEquals(SyntheticsTestPauseStatus.PAUSED, result.status)
-    }
-
-    @Test
     fun `status sets status of a test`() {
         testBuilder.status(SyntheticsTestPauseStatus.LIVE)
         val result = testBuilder.build()
 
         assertEquals(SyntheticsTestPauseStatus.LIVE, result.status)
+    }
+
+    @Test
+    fun `build specifies no status by default`() {
+        val result = testBuilder.build()
+        assertNull(result.status)
     }
 }


### PR DESCRIPTION
## Scope

This PR changes the status behaviour for new implementations of Multi-step API and Browser tests: the `status` is no longer set as `paused` by default.