### PR TITLE
Prepare to release 2.3.0 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,14 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
-- Make the test `status` not set by default ([#144](https://github.com/personio/datadog-synthetic-test-support/pull/144))
 
 ### Bug fixes
 
 ### Dependencies
+
+## [2.3.0] - 2023-10-23
+### New features & improvements
+- Make the test `status` not set by default ([#144](https://github.com/personio/datadog-synthetic-test-support/pull/144))
 
 ## [2.2.0] - 2023-10-20
 ### New features & improvements


### PR DESCRIPTION
Problem: In order to prepare to the new release Changelog file should contain a new release section.
Solution: Add a new release section 2.3.0 to the Changelog