### PR TITLE
PAYINT: Adds new assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Bug fixes: any changes that fix issues or bug in the existing code
 - Dependencies: updates of dependency versions
 
-## [Unreleased] - yyyy-mm-dd
+## [Unreleased] - 2024-01-02
 
 ### Breaking changes
 
 ### New features & improvements
+- Adds `bodyDoesNotContain()` method to create assertions checking for non-existent values in body content
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/AssertionsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/AssertionsBuilder.kt
@@ -66,13 +66,25 @@ class AssertionsBuilder {
     }
 
     /**
-     * Asserts that the response body contains the given value
-     * @param value Value to look for
+     * asserts that the response body contains the given value
+     * @param value value to look for
      */
     fun bodyContains(value: Any) {
         target(
             SyntheticsAssertionType.BODY,
             SyntheticsAssertionOperator.CONTAINS,
+            value
+        )
+    }
+
+    /**
+     * asserts that the response body does not contain the given value
+     * @param value value to look for
+     */
+    fun bodyDoesNotContain(value: Any) {
+        target(
+            SyntheticsAssertionType.BODY,
+            SyntheticsAssertionOperator.DOES_NOT_CONTAIN,
             value
         )
     }

--- a/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
@@ -85,6 +85,22 @@ class AssertionsBuilderTest {
     }
 
     @Test
+    fun `bodyDoesNotContains adds assertion that checks if the body does not contain the given raw value`() {
+        assertionsBuilder.bodyDoesNotContain("any_value")
+        val result = assertionsBuilder.build()
+
+        assertEquals(
+            SyntheticsAssertion(
+                SyntheticsAssertionTarget()
+                    .operator(SyntheticsAssertionOperator.DOES_NOT_CONTAIN)
+                    .target("any_value")
+                    .type(SyntheticsAssertionType.BODY)
+            ),
+            result.first()
+        )
+    }
+
+    @Test
     fun `build returns list of assertions`() {
         assertionsBuilder.statusCode(200)
         assertionsBuilder.headerContains("any_header", "any_value")


### PR DESCRIPTION
- Adds `bodyDoesNotContain()` method to create assertions checking for non-existent values in body content