### PR TITLE
Assertion does not contain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
+- Add `bodyDoesNotContain()` assertion function to check if a response body doesn't contain specific values
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/AssertionsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/AssertionsBuilder.kt
@@ -78,6 +78,18 @@ class AssertionsBuilder {
     }
 
     /**
+     * Asserts that the response body does not contain the given value
+     * @param value Value to look for
+     */
+    fun bodyDoesNotContain(value: Any) {
+        target(
+            SyntheticsAssertionType.BODY,
+            SyntheticsAssertionOperator.DOES_NOT_CONTAIN,
+            value
+        )
+    }
+
+    /**
      * Adds an assertion for a given assertion type, operator and target
      * @param type Assertion type
      * @param operator Assertion operator

--- a/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
@@ -85,6 +85,22 @@ class AssertionsBuilderTest {
     }
 
     @Test
+    fun `bodyDoesNotContains adds assertion that checks if the body does not contain the given raw value`() {
+        assertionsBuilder.bodyDoesNotContain("any_value")
+        val result = assertionsBuilder.build()
+
+        assertEquals(
+            SyntheticsAssertion(
+                SyntheticsAssertionTarget()
+                    .operator(SyntheticsAssertionOperator.DOES_NOT_CONTAIN)
+                    .target("any_value")
+                    .type(SyntheticsAssertionType.BODY)
+            ),
+            result.first()
+        )
+    }
+
+    @Test
     fun `build returns list of assertions`() {
         assertionsBuilder.statusCode(200)
         assertionsBuilder.headerContains("any_header", "any_value")


### PR DESCRIPTION
- Add `bodyDoesNotContain()` method to create assertions checking for non-existent values in body content.
Now, when using the `assertions` block, users can:
```
assertions {
    bodyDoesNotContain("text")
}
```