### PR TITLE
Implement `wait` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
--  Refactor the Browser tests to use the builder approach ([#188](https://github.com/personio/datadog-synthetic-test-support/pull/188), [#189](https://github.com/personio/datadog-synthetic-test-support/pull/189))
+-  Refactor the Browser tests to use the builder approach ([#188](https://github.com/personio/datadog-synthetic-test-support/pull/188), [#189](https://github.com/personio/datadog-synthetic-test-support/pull/189), [#190](https://github.com/personio/datadog-synthetic-test-support/pull/190))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/browser/StepsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/browser/StepsBuilder.kt
@@ -4,7 +4,9 @@ import com.datadog.api.client.v1.model.SyntheticsStep
 import com.datadog.api.client.v1.model.SyntheticsStepType
 import com.personio.synthetics.model.actions.ActionsParams
 import com.personio.synthetics.model.actions.SpecialActionsParams
+import com.personio.synthetics.model.actions.WaitParams
 import com.personio.synthetics.step.ui.model.TargetElement
+import kotlin.time.Duration
 
 private const val DEFAULT_TEXT_DELAY_MILLIS: Long = 25
 
@@ -15,6 +17,11 @@ class StepsBuilder {
         return steps
     }
 
+    /**
+     * Adds a new "type text" step to the synthetic browser test
+     * @param stepName Name of the step
+     * @param targetElement The web element where the text needs to be set
+     */
     fun typeText(
         stepName: String,
         targetElement: TargetElement,
@@ -32,6 +39,11 @@ class StepsBuilder {
         )
     }
 
+    /**
+     * Adds a new click step to the synthetic browser test
+     * @param stepName Name of the step
+     * @param targetElement The web element where the click is to be performed
+     */
     fun click(
         stepName: String,
         targetElement: TargetElement,
@@ -46,6 +58,11 @@ class StepsBuilder {
         )
     }
 
+    /**
+     * Adds a new hover step to the synthetic browser test
+     * @param stepName Name of the step
+     * @param targetElement The web element to which the hover has to be performed
+     */
     fun hover(
         stepName: String,
         targetElement: TargetElement,
@@ -57,6 +74,22 @@ class StepsBuilder {
                 SpecialActionsParams(
                     element = targetElement.getSpecialActionsElementObject(),
                 ),
+        )
+    }
+
+    /**
+     * Adds a new wait step to the synthetic browser test
+     * @param stepName Name of the step
+     * @param duration The duration to wait
+     */
+    fun wait(
+        stepName: String,
+        duration: Duration,
+    ) {
+        addStep(
+            stepName = stepName,
+            type = SyntheticsStepType.WAIT,
+            params = WaitParams(value = duration.inWholeSeconds.toInt()),
         )
     }
 

--- a/src/test/kotlin/com/personio/synthetics/builder/browser/StepsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/browser/StepsBuilderTest.kt
@@ -6,9 +6,11 @@ import com.personio.synthetics.TEST_LOCATOR
 import com.personio.synthetics.TEST_STEP_NAME
 import com.personio.synthetics.model.actions.ActionsParams
 import com.personio.synthetics.model.actions.SpecialActionsParams
+import com.personio.synthetics.model.actions.WaitParams
 import com.personio.synthetics.step.ui.model.TargetElement
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import kotlin.time.Duration.Companion.seconds
 
 class StepsBuilderTest {
     @Test
@@ -72,6 +74,23 @@ class StepsBuilderTest {
                         element = TargetElement(TEST_LOCATOR).getSpecialActionsElementObject(),
                     ),
                 ),
+            result.first(),
+        )
+    }
+
+    @Test
+    fun `wait adds wait step`() {
+        val sut = StepsBuilder()
+        sut.wait(TEST_STEP_NAME, 5.seconds)
+
+        val result = sut.build()
+
+        assertEquals(1, result.count())
+        assertEquals(
+            SyntheticsStep()
+                .name(TEST_STEP_NAME)
+                .type(SyntheticsStepType.WAIT)
+                .params(WaitParams(5)),
             result.first(),
         )
     }

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EBrowserTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EBrowserTest.kt
@@ -14,6 +14,7 @@ import java.time.LocalTime
 import java.time.ZoneId
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
 
 /**
  * Since the builder is still in progress, don't use it for the browser test creation
@@ -52,6 +53,7 @@ class E2EBrowserTest {
                 typeText("Type text", TargetElement("#my-element"), "new_text")
                 click("Click", TargetElement("#my-element"))
                 hover("Hover", TargetElement("#my-element"))
+                wait("Wait", 3.seconds)
             }
         }
     }


### PR DESCRIPTION
## Why

This PR is part of an effort to split https://github.com/personio/datadog-synthetic-test-support/pull/156 into smaller, manageable and reviewable pull requests.

## Scope

This PR supports the `wait` step in the browser test implementation.