### PR TITLE
Implement `refresh` step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
--  Refactor the Browser tests to use the builder approach ([#188](https://github.com/personio/datadog-synthetic-test-support/pull/188), [#189](https://github.com/personio/datadog-synthetic-test-support/pull/189), [#190](https://github.com/personio/datadog-synthetic-test-support/pull/190))
+-  Refactor the Browser tests to use the builder approach ([#188](https://github.com/personio/datadog-synthetic-test-support/pull/188), [#189](https://github.com/personio/datadog-synthetic-test-support/pull/189), [#190](https://github.com/personio/datadog-synthetic-test-support/pull/190), [#197](https://github.com/personio/datadog-synthetic-test-support/pull/197))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/browser/StepsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/browser/StepsBuilder.kt
@@ -2,6 +2,7 @@ package com.personio.synthetics.builder.browser
 
 import com.datadog.api.client.v1.model.SyntheticsStep
 import com.datadog.api.client.v1.model.SyntheticsStepType
+import com.personio.synthetics.model.Params
 import com.personio.synthetics.model.actions.ActionsParams
 import com.personio.synthetics.model.actions.SpecialActionsParams
 import com.personio.synthetics.model.actions.WaitParams
@@ -90,6 +91,18 @@ class StepsBuilder {
             stepName = stepName,
             type = SyntheticsStepType.WAIT,
             params = WaitParams(value = duration.inWholeSeconds.toInt()),
+        )
+    }
+
+    /**
+     * Adds a new refresh step to the synthetic browser test
+     * @param stepName Name of the step
+     */
+    fun refresh(stepName: String) {
+        addStep(
+            stepName = stepName,
+            type = SyntheticsStepType.REFRESH,
+            params = Params(),
         )
     }
 

--- a/src/test/kotlin/com/personio/synthetics/builder/browser/StepsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/browser/StepsBuilderTest.kt
@@ -94,4 +94,16 @@ class StepsBuilderTest {
             result.first(),
         )
     }
+
+    @Test
+    fun `refresh adds refresh step`() {
+        val sut = StepsBuilder()
+        sut.refresh(TEST_STEP_NAME)
+
+        val result = sut.build()
+
+        assertEquals(1, result.count())
+        assertEquals(SyntheticsStepType.REFRESH, result.first().type)
+        assertEquals(TEST_STEP_NAME, result.first().name)
+    }
 }

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EBrowserTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EBrowserTest.kt
@@ -54,6 +54,7 @@ class E2EBrowserTest {
                 click("Click", TargetElement("#my-element"))
                 hover("Hover", TargetElement("#my-element"))
                 wait("Wait", 3.seconds)
+                refresh("Refresh")
             }
         }
     }


### PR DESCRIPTION
## Why
This PR is part of an effort to split https://github.com/personio/datadog-synthetic-test-support/pull/156 into smaller, manageable and reviewable pull requests.

## Scope
This PR supports the `refresh` step in the browser test implementation.