### PR TITLE
Avoid unwanted parallel executions during Datadog test updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
+- Add a wrapper to `createBrowserTest()` to avoid unwanted parallel executions during Datadog test updates [#223](https://github.com/personio/datadog-synthetic-test-support/pull/223)
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
+++ b/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
@@ -77,20 +77,23 @@ class BrowserTest(
     internal fun createBrowserTest(): SyntheticsBrowserTest {
         val testId = getTestId()
         return if (testId != null) {
-            syntheticsApiClient.updateTestPauseStatus(
-                testId,
-                SyntheticsUpdateTestPauseStatusPayload().newStatus(
-                    SyntheticsTestPauseStatus.PAUSED,
-                ),
-            )
-            syntheticsApiClient.updateBrowserTest(testId, this)
-                .also {
+            if (syntheticsApiClient.getTest(testId).status.equals(SyntheticsTestPauseStatus.LIVE)) {
                 syntheticsApiClient.updateTestPauseStatus(
                     testId,
                     SyntheticsUpdateTestPauseStatusPayload().newStatus(
-                        SyntheticsTestPauseStatus.LIVE,
+                        SyntheticsTestPauseStatus.PAUSED,
                     ),
                 )
+                syntheticsApiClient.updateBrowserTest(testId, this).also {
+                    syntheticsApiClient.updateTestPauseStatus(
+                        testId,
+                        SyntheticsUpdateTestPauseStatusPayload().newStatus(
+                            SyntheticsTestPauseStatus.LIVE,
+                        ),
+                    )
+                }
+            } else {
+                syntheticsApiClient.updateBrowserTest(testId, this)
             }
         } else {
             syntheticsApiClient.createSyntheticsBrowserTest(this)

--- a/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
+++ b/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
@@ -6,6 +6,8 @@ import com.datadog.api.client.v1.model.SyntheticsDeviceID
 import com.datadog.api.client.v1.model.SyntheticsTestOptions
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsMonitorOptions
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsRetry
+import com.datadog.api.client.v1.model.SyntheticsTestPauseStatus
+import com.datadog.api.client.v1.model.SyntheticsUpdateTestPauseStatusPayload
 import com.personio.synthetics.config.Config
 import com.personio.synthetics.config.Defaults
 import com.personio.synthetics.config.loadConfiguration
@@ -75,7 +77,21 @@ class BrowserTest(
     internal fun createBrowserTest(): SyntheticsBrowserTest {
         val testId = getTestId()
         return if (testId != null) {
+            syntheticsApiClient.updateTestPauseStatus(
+                testId,
+                SyntheticsUpdateTestPauseStatusPayload().newStatus(
+                    SyntheticsTestPauseStatus.PAUSED,
+                ),
+            )
             syntheticsApiClient.updateBrowserTest(testId, this)
+                .also {
+                syntheticsApiClient.updateTestPauseStatus(
+                    testId,
+                    SyntheticsUpdateTestPauseStatusPayload().newStatus(
+                        SyntheticsTestPauseStatus.LIVE,
+                    ),
+                )
+            }
         } else {
             syntheticsApiClient.createSyntheticsBrowserTest(this)
         }


### PR DESCRIPTION
When tests are updated in Datadog, there is a chance that two parallel runs may be scheduled, especially for tests with high frequency. This increases the likelihood of flaky tests.

This change wraps the update statement with pause and resume, preventing these issues from occurring.