### PR TITLE
adds method to match regex for a given json path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
--  Refactor the Browser tests to use the builder approach ([#188](https://github.com/personio/datadog-synthetic-test-support/pull/188), [#189](https://github.com/personio/datadog-synthetic-test-support/pull/189), [#190](https://github.com/personio/datadog-synthetic-test-support/pull/190), [#197](https://github.com/personio/datadog-synthetic-test-support/pull/197))
+- Refactor the Browser tests to use the builder approach ([#188](https://github.com/personio/datadog-synthetic-test-support/pull/188), [#189](https://github.com/personio/datadog-synthetic-test-support/pull/189), [#190](https://github.com/personio/datadog-synthetic-test-support/pull/190), [#197](https://github.com/personio/datadog-synthetic-test-support/pull/197))
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### New features & improvements
 - Refactor the Browser tests to use the builder approach ([#188](https://github.com/personio/datadog-synthetic-test-support/pull/188), [#189](https://github.com/personio/datadog-synthetic-test-support/pull/189), [#190](https://github.com/personio/datadog-synthetic-test-support/pull/190), [#197](https://github.com/personio/datadog-synthetic-test-support/pull/197))
+- Add `bodyContainsJsonPathRegex()` assertion function to check if a json path element in a response body matches given regex [#228](https://github.com/personio/datadog-synthetic-test-support/pull/228)
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/AssertionsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/AssertionsBuilder.kt
@@ -72,6 +72,30 @@ class AssertionsBuilder {
     }
 
     /**
+     * Asserts that the value at the JSON path in the response body matches the given regex
+     * @param jsonPath JSON path
+     * @param regex Value to match with
+     */
+    fun bodyContainsJsonPathRegex(
+        jsonPath: String,
+        regex: String,
+    ) {
+        assertions.add(
+            SyntheticsAssertion(
+                SyntheticsAssertionJSONPathTarget()
+                    .operator(SyntheticsAssertionJSONPathOperator.VALIDATES_JSON_PATH)
+                    .type(SyntheticsAssertionType.BODY)
+                    .target(
+                        SyntheticsAssertionJSONPathTargetTarget()
+                            .jsonPath(jsonPath)
+                            .targetValue(regex)
+                            .operator("matches"),
+                    ),
+            ),
+        )
+    }
+
+    /**
      * Asserts that the response body contains the given value
      * @param value Value to look for
      */

--- a/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
@@ -68,6 +68,27 @@ class AssertionsBuilderTest {
     }
 
     @Test
+    fun `bodyContainsJsonPathRegex adds assertion that macthes the value stored in the given json path against the regex provided`() {
+        assertionsBuilder.bodyContainsJsonPathRegex("any_json_path", "any_regex")
+        val result = assertionsBuilder.build()
+
+        assertEquals(
+            SyntheticsAssertion(
+                SyntheticsAssertionJSONPathTarget()
+                    .operator(SyntheticsAssertionJSONPathOperator.VALIDATES_JSON_PATH)
+                    .type(SyntheticsAssertionType.BODY)
+                    .target(
+                        SyntheticsAssertionJSONPathTargetTarget()
+                            .jsonPath("any_json_path")
+                            .operator("matches")
+                            .targetValue("any_regex"),
+                    ),
+            ),
+            result.first(),
+        )
+    }
+
+    @Test
     fun `bodyContains adds assertion that checks if the body contains the given raw value`() {
         assertionsBuilder.bodyContains("any_value")
         val result = assertionsBuilder.build()

--- a/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
@@ -68,7 +68,7 @@ class AssertionsBuilderTest {
     }
 
     @Test
-    fun `bodyContainsJsonPathRegex adds assertion that macthes the value stored in the given json path against the regex provided`() {
+    fun `bodyContainsJsonPathRegex adds assertion that matches the value stored in the given JSON path against the RegEx provided`() {
         assertionsBuilder.bodyContainsJsonPathRegex("any_json_path", "any_regex")
         val result = assertionsBuilder.build()
 

--- a/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/AssertionsBuilderTest.kt
@@ -69,7 +69,7 @@ class AssertionsBuilderTest {
 
     @Test
     fun `bodyContainsJsonPathRegex adds assertion that matches the value stored in the given JSON path against the RegEx provided`() {
-        assertionsBuilder.bodyContainsJsonPathRegex("any_json_path", "any_regex")
+        assertionsBuilder.bodyContainsJsonPathRegex("$.foo.bar", "^t.[u].\$")
         val result = assertionsBuilder.build()
 
         assertEquals(
@@ -79,9 +79,9 @@ class AssertionsBuilderTest {
                     .type(SyntheticsAssertionType.BODY)
                     .target(
                         SyntheticsAssertionJSONPathTargetTarget()
-                            .jsonPath("any_json_path")
+                            .jsonPath("$.foo.bar")
                             .operator("matches")
-                            .targetValue("any_regex"),
+                            .targetValue("^t.[u].\$"),
                     ),
             ),
             result.first(),

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -80,6 +80,8 @@ class E2EMultiStepApiTest {
                         assertions {
                             statusCode(200)
                             bodyContainsJsonPath("\$.success", "true")
+                            // regex to match "t{single-char}u{single-char}"
+                            bodyContainsJsonPathRegex("\$.success", "^t.[u].\$")
                             bodyContains("some_data")
                             headerContains("set-cookie", "cookie_name")
                         }

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -80,7 +80,6 @@ class E2EMultiStepApiTest {
                         assertions {
                             statusCode(200)
                             bodyContainsJsonPath("\$.success", "true")
-                            // regex to match "t{single-char}u{single-char}"
                             bodyContainsJsonPathRegex("\$.success", "^t.[u].\$")
                             bodyContains("some_data")
                             headerContains("set-cookie", "cookie_name")


### PR DESCRIPTION
Similar to `bodyContainsJsonPath` method a new method `bodyContainsJsonPathRegex` is added to match a given regex string to json path.

This could be useful when matching something like dates, numeric ids, etc. on a response body. Currently we do have support to create a regex based assertion on the DD UI (screenshot)

<img width="586" alt="Screenshot 2024-08-05 at 21 00 55" src="https://github.com/user-attachments/assets/4313125c-407c-485c-9332-f3ae77bd5123">
