### PR TITLE
adds raw body extraction method for API tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
+- Add `bodyRaw()` extraction function for API Tests to extract entire response body
 
 ### Bug fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
-- Add `bodyRaw()` extraction function for API Tests to extract entire response body
+- Add `bodyRaw()` extraction function for API Tests to extract entire response body ([#238](https://github.com/personio/datadog-synthetic-test-support/pull/238))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilder.kt
@@ -68,6 +68,22 @@ class ParsingOptionsBuilder {
     }
 
     /**
+     * Extracts the entire response body
+     * @param secure set to true to disallow the extracted value to be read from DataDog UI
+     * By default secure is set to false allowing the extracted value to be available for reading in Datadog UI
+     */
+    fun bodyRaw(secure: Boolean = false) {
+        parsingOptions =
+            SyntheticsParsingOptions()
+                .parser(
+                    SyntheticsVariableParser()
+                        .type(SyntheticsGlobalVariableParserType.RAW),
+                )
+                .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_BODY)
+                .secure(secure)
+    }
+
+    /**
      * Extracts the value from a response header
      * @param name Header name
      * @param secure Set to true to disallow the extracted value to be read from DataDog UI

--- a/src/test/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/parsing/ParsingOptionsBuilderTest.kt
@@ -81,6 +81,25 @@ class ParsingOptionsBuilderTest {
 
     @ParameterizedTest
     @ValueSource(booleans = [true, false])
+    fun `bodyRaw returns parsing options with RAW parser type and HTTP_BODY type`(secure: Boolean) {
+        parsingOptionsBuilder.variable(TEST_STEP_NAME)
+        parsingOptionsBuilder.bodyRaw(secure)
+
+        assertEquals(
+            SyntheticsParsingOptions()
+                .name(TEST_STEP_NAME)
+                .parser(
+                    SyntheticsVariableParser()
+                        .type(SyntheticsGlobalVariableParserType.RAW),
+                )
+                .type(SyntheticsGlobalVariableParseTestOptionsType.HTTP_BODY)
+                .secure(secure),
+            parsingOptionsBuilder.build(),
+        )
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
     fun `header returns parsing options with RAW parser type and HTTP_HEADER type`(secure: Boolean) {
         parsingOptionsBuilder.variable(TEST_STEP_NAME)
         parsingOptionsBuilder.header("any_header_name", secure)

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -87,6 +87,9 @@ class E2EMultiStepApiTest {
                         extract("COOKIE_VARIABLE") {
                             headerRegex("set-cookie", "(?<=cookie_name\\=)[^;]+(?=;)")
                         }
+                        extract("RAW_RESPONSE_BODY") {
+                            bodyRaw()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
### Context
A new method `bodyRaw()` is added to extract the entire response body from an API test step. This is currently supported on the DD UI by option `Use Full Response Body`

![Screenshot 2024-09-06 at 10 29 06](https://github.com/user-attachments/assets/9b86a59f-074b-4b33-9585-293f6c31d2f3)



### Testing

Tested it with an example test and it populated the extraction of body as expected on the DD UI:

<img width="752" alt="Screenshot 2024-09-06 at 13 18 43" src="https://github.com/user-attachments/assets/4d6aa80f-f876-4c22-b484-671da40a94de">
