### PR TITLE
feature: adds wait step creator for API Tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
+- Add a new `wait` step creation function for API Tests ([#255](https://github.com/personio/datadog-synthetic-test-support/pull/255))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
@@ -56,22 +56,24 @@ class StepBuilder(
         return if (waitDuration != null) buildWaitStep() else buildRequestStep()
     }
 
-    private fun buildWaitStep() = SyntheticsAPIStep(
-        SyntheticsAPIWaitStep()
-            .name(name)
-            .subtype(SyntheticsAPIWaitStepSubtype.WAIT)
-            .value(waitDuration),
-    )
+    private fun buildWaitStep() =
+        SyntheticsAPIStep(
+            SyntheticsAPIWaitStep()
+                .name(name)
+                .subtype(SyntheticsAPIWaitStepSubtype.WAIT)
+                .value(waitDuration),
+        )
 
-    private fun buildRequestStep() = SyntheticsAPIStep(
-        step.syntheticsAPITestStep
-            .request(request)
-            .allowFailure(allowFailure)
-            .retry(retryOptions)
-            .name(name)
-            .assertions(assertions)
-            .subtype(SyntheticsAPITestStepSubtype.HTTP),
-    )
+    private fun buildRequestStep() =
+        SyntheticsAPIStep(
+            step.syntheticsAPITestStep
+                .request(request)
+                .allowFailure(allowFailure)
+                .retry(retryOptions)
+                .name(name)
+                .assertions(assertions)
+                .subtype(SyntheticsAPITestStepSubtype.HTTP),
+        )
 
     /**
      * Sets the HTTP request for the synthetic test

--- a/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
@@ -52,29 +52,26 @@ class StepBuilder(
         if (parsingOptions.isNotEmpty()) {
             step.syntheticsAPITestStep.extractedValues(parsingOptions)
         }
-        return if (waitDuration != null) {
-            buildWaitStep()
-        } else {
-            SyntheticsAPIStep(
-                step.syntheticsAPITestStep
-                    .request(request)
-                    .allowFailure(allowFailure)
-                    .retry(retryOptions)
-                    .name(name)
-                    .assertions(assertions)
-                    .subtype(SyntheticsAPITestStepSubtype.HTTP),
-            )
-        }
+
+        return if (waitDuration != null) buildWaitStep() else buildRequestStep()
     }
 
-    private fun buildWaitStep(): SyntheticsAPIStep {
-        return SyntheticsAPIStep(
-            SyntheticsAPIWaitStep()
-                .name(name)
-                .subtype(SyntheticsAPIWaitStepSubtype.WAIT)
-                .value(waitDuration),
-        )
-    }
+    private fun buildWaitStep() = SyntheticsAPIStep(
+        SyntheticsAPIWaitStep()
+            .name(name)
+            .subtype(SyntheticsAPIWaitStepSubtype.WAIT)
+            .value(waitDuration),
+    )
+
+    private fun buildRequestStep() = SyntheticsAPIStep(
+        step.syntheticsAPITestStep
+            .request(request)
+            .allowFailure(allowFailure)
+            .retry(retryOptions)
+            .name(name)
+            .assertions(assertions)
+            .subtype(SyntheticsAPITestStepSubtype.HTTP),
+    )
 
     /**
      * Sets the HTTP request for the synthetic test
@@ -135,7 +132,7 @@ class StepBuilder(
 
     /**
      * Creates a wait step
-     * @param durationInSeconds The duration to wait in seconds. Minimum value: 0. Maximum value: 180
+     * @param durationInSeconds The duration to wait in seconds. Minimum value: 1. Maximum value: 180
      */
     fun wait(durationInSeconds: Int) {
         require(durationInSeconds in 1..180) {

--- a/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
@@ -66,10 +66,11 @@ class StepBuilder(
     }
 
     private fun buildWaitStep(): SyntheticsAPIStep {
-        return SyntheticsAPIStep(SyntheticsAPIWaitStep()
-            .name(name)
-            .subtype(SyntheticsAPIWaitStepSubtype.WAIT)
-            .value(waitDuration)
+        return SyntheticsAPIStep(
+            SyntheticsAPIWaitStep()
+                .name(name)
+                .subtype(SyntheticsAPIWaitStepSubtype.WAIT)
+                .value(waitDuration),
         )
     }
 

--- a/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
@@ -135,12 +135,12 @@ class StepBuilder(
 
     /**
      * Creates a wait step
-     * @param duration The duration to wait in seconds. Minimum value: 0. Maximum value: 180
+     * @param durationInSeconds The duration to wait in seconds. Minimum value: 0. Maximum value: 180
      */
-    fun wait(duration: Int) {
-        require(duration in 0..180) {
-            "Duration to wait must be in range 0 to 180 seconds."
+    fun wait(durationInSeconds: Int) {
+        require(durationInSeconds in 1..180) {
+            "Duration to wait must be in range 1 to 180 seconds."
         }
-        waitDuration = duration
+        waitDuration = durationInSeconds
     }
 }

--- a/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
@@ -40,9 +40,11 @@ class StepBuilder(
 
     fun build(): SyntheticsAPIStep {
         if (request == null && waitDuration == null) {
-            throw IllegalStateException("Provide either of `Request or Wait instruction`.")
+            throw IllegalStateException("Provide either of Request or Wait duration.")
         }
-
+        if (request != null && waitDuration != null) {
+            throw IllegalStateException("Only one of Request or Wait duration should be provided.")
+        }
         if (allowFailure) {
             step.syntheticsAPITestStep.isCritical(isCritical)
         }

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
@@ -85,19 +85,6 @@ class StepBuilderTest {
     }
 
     @Test
-    fun `build fails a wait step when waitDuration is provided`() {
-        val stepBuilder = StepBuilder(TEST_STEP_NAME)
-        stepBuilder.wait(30)
-
-        val result = stepBuilder.build()
-
-        assertEquals(
-            SyntheticsAPIWaitStep(TEST_STEP_NAME, SyntheticsAPIWaitStepSubtype.WAIT, 30),
-            result.syntheticsAPIWaitStep,
-        )
-    }
-
-    @Test
     fun `assertions sets assertions properly`() {
         val assertionsMock =
             makeAssertionBuilderMock(
@@ -149,9 +136,25 @@ class StepBuilderTest {
             .thenReturn(null)
         val stepBuilder = StepBuilder(TEST_STEP_NAME, requestBuilderMock)
 
-        assertThrows<IllegalStateException> {
-            stepBuilder.build()
-        }
+        val exception =
+            assertThrows<IllegalStateException> {
+                stepBuilder.build()
+            }
+        assertEquals(exception.message, "Provide either of Request or Wait duration.")
+    }
+
+    @Test
+    fun `build throws IllegalStateException when both request & waitDuration are provided`() {
+        val requestBuilderMock = makeRequestBuilderHappyPathMock()
+        val stepBuilder = StepBuilder(TEST_STEP_NAME, requestBuilderMock)
+        stepBuilder.request { }
+        stepBuilder.wait(30)
+
+        val exception =
+            assertThrows<IllegalStateException> {
+                stepBuilder.build()
+            }
+        assertEquals(exception.message, "Only one of Request or Wait duration should be provided.")
     }
 
     @Test

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
@@ -72,7 +72,7 @@ class StepBuilderTest {
     }
 
     @Test
-    fun `build creates a wait step when waitDuration is provided`() {
+    fun `build creates a wait step when wait duration is provided`() {
         val stepBuilder = StepBuilder(TEST_STEP_NAME)
         stepBuilder.wait(30)
 
@@ -82,6 +82,15 @@ class StepBuilderTest {
             SyntheticsAPIWaitStep(TEST_STEP_NAME, SyntheticsAPIWaitStepSubtype.WAIT, 30),
             result.syntheticsAPIWaitStep,
         )
+    }
+
+    @Test
+    fun `wait throws exception for invalid duration`() {
+        val stepBuilder = StepBuilder(TEST_STEP_NAME)
+
+        assertThrows<IllegalArgumentException> {
+            stepBuilder.wait(300)
+        }
     }
 
     @Test
@@ -130,7 +139,7 @@ class StepBuilderTest {
     }
 
     @Test
-    fun `build throws IllegalStateException when both request & waitDuration are null`() {
+    fun `build throws IllegalStateException when both request & wait duration are null`() {
         val requestBuilderMock = Mockito.mock(RequestBuilder::class.java)
         whenever(requestBuilderMock.build())
             .thenReturn(null)
@@ -144,7 +153,7 @@ class StepBuilderTest {
     }
 
     @Test
-    fun `build throws IllegalStateException when both request & waitDuration are provided`() {
+    fun `build throws IllegalStateException when both request & wait duration are provided`() {
         val requestBuilderMock = makeRequestBuilderHappyPathMock()
         val stepBuilder = StepBuilder(TEST_STEP_NAME, requestBuilderMock)
         stepBuilder.request { }

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
@@ -1,6 +1,8 @@
 package com.personio.synthetics.builder.api
 
 import com.datadog.api.client.v1.model.SyntheticsAPITestStepSubtype
+import com.datadog.api.client.v1.model.SyntheticsAPIWaitStep
+import com.datadog.api.client.v1.model.SyntheticsAPIWaitStepSubtype
 import com.datadog.api.client.v1.model.SyntheticsAssertion
 import com.datadog.api.client.v1.model.SyntheticsParsingOptions
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsRetry
@@ -70,6 +72,32 @@ class StepBuilderTest {
     }
 
     @Test
+    fun `build creates a wait step when waitDuration is provided`() {
+        val stepBuilder = StepBuilder(TEST_STEP_NAME)
+        stepBuilder.wait(30)
+
+        val result = stepBuilder.build()
+
+        assertEquals(
+            SyntheticsAPIWaitStep(TEST_STEP_NAME, SyntheticsAPIWaitStepSubtype.WAIT, 30),
+            result.syntheticsAPIWaitStep
+        )
+    }
+
+    @Test
+    fun `build fails a wait step when waitDuration is provided`() {
+        val stepBuilder = StepBuilder(TEST_STEP_NAME)
+        stepBuilder.wait(30)
+
+        val result = stepBuilder.build()
+
+        assertEquals(
+            SyntheticsAPIWaitStep(TEST_STEP_NAME, SyntheticsAPIWaitStepSubtype.WAIT, 30),
+            result.syntheticsAPIWaitStep
+        )
+    }
+
+    @Test
     fun `assertions sets assertions properly`() {
         val assertionsMock =
             makeAssertionBuilderMock(
@@ -115,7 +143,7 @@ class StepBuilderTest {
     }
 
     @Test
-    fun `build throws IllegalStateException when request is null`() {
+    fun `build throws IllegalStateException when both request & waitDuration are null`() {
         val requestBuilderMock = Mockito.mock(RequestBuilder::class.java)
         whenever(requestBuilderMock.build())
             .thenReturn(null)

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
@@ -89,7 +89,10 @@ class StepBuilderTest {
         val stepBuilder = StepBuilder(TEST_STEP_NAME)
 
         assertThrows<IllegalArgumentException> {
-            stepBuilder.wait(300)
+            stepBuilder.wait(0)
+        }
+        assertThrows<IllegalArgumentException> {
+            stepBuilder.wait(181)
         }
     }
 

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
@@ -80,7 +80,7 @@ class StepBuilderTest {
 
         assertEquals(
             SyntheticsAPIWaitStep(TEST_STEP_NAME, SyntheticsAPIWaitStepSubtype.WAIT, 30),
-            result.syntheticsAPIWaitStep
+            result.syntheticsAPIWaitStep,
         )
     }
 
@@ -93,7 +93,7 @@ class StepBuilderTest {
 
         assertEquals(
             SyntheticsAPIWaitStep(TEST_STEP_NAME, SyntheticsAPIWaitStepSubtype.WAIT, 30),
-            result.syntheticsAPIWaitStep
+            result.syntheticsAPIWaitStep,
         )
     }
 

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -20,7 +20,7 @@ class E2EMultiStepApiTest {
      * This test creates a Synthetic Multi-Step API test in Datadog.
      */
     @Test
-    fun `create mutli-step api synthetic test`() {
+    fun `create multi-step api synthetic test`() {
         syntheticMultiStepApiTest("[Multi-Step] Synthetic-Test-As-Code") {
             alertMessage("Test failed", "@slack-test_slack_channel")
             recoveryMessage("Test recovered")

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZoneId
-import java.time.temporal.ChronoUnit
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
 import java.time.LocalTime
 import java.time.ZoneId
+import java.time.temporal.ChronoUnit
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
@@ -91,6 +92,9 @@ class E2EMultiStepApiTest {
                             bodyRaw()
                         }
                     }
+                }
+                step("Wait for 5 seconds") {
+                    wait(5)
                 }
             }
         }


### PR DESCRIPTION
This MR adds support to create Wait steps for API Tests, which is currently available through the DD UI (_screenshot below_)

<kbd>
<img width="800" alt="Screenshot 2024-11-04 at 18 20 08" src="https://github.com/user-attachments/assets/2cfe3f81-92e9-439c-b63e-381ffdda2ced" >
</kbd>

### Testing

1. Ran `./gradlew e2eTest`
2. The test ran successfully and created the step on DD UI
<kbd>
<img width="797" alt="Screenshot 2024-11-04 at 18 20 25" src="https://github.com/user-attachments/assets/67ea4bb3-5ba9-41bb-b1e7-58bb0bac49d1">
</kbd>
