### PR TITLE
Update wait API step to use Duration unit instead of Int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
-- Add a new `wait` step creation function for API Tests ([#255](https://github.com/personio/datadog-synthetic-test-support/pull/255))
+- Add a new `wait` step creation function for API Tests ([#255](https://github.com/personio/datadog-synthetic-test-support/pull/255), [#265](https://github.com/personio/datadog-synthetic-test-support/pull/265))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/api/StepBuilder.kt
@@ -134,12 +134,13 @@ class StepBuilder(
 
     /**
      * Creates a wait step
-     * @param durationInSeconds The duration to wait in seconds. Minimum value: 1. Maximum value: 180
+     * @param duration The duration of wait in seconds or minutes
+     * Allowed wait step duration is between 1 second and 3 minutes
      */
-    fun wait(durationInSeconds: Int) {
-        require(durationInSeconds in 1..180) {
-            "Duration to wait must be in range 1 to 180 seconds."
+    fun wait(duration: Duration) {
+        require(duration in 1.seconds..180.seconds) {
+            "Wait duration should be between 1 and 180 seconds."
         }
-        waitDuration = durationInSeconds
+        waitDuration = duration.inWholeSeconds.toInt()
     }
 }

--- a/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/builder/api/StepBuilderTest.kt
@@ -74,7 +74,7 @@ class StepBuilderTest {
     @Test
     fun `build creates a wait step when wait duration is provided`() {
         val stepBuilder = StepBuilder(TEST_STEP_NAME)
-        stepBuilder.wait(30)
+        stepBuilder.wait(30.seconds)
 
         val result = stepBuilder.build()
 
@@ -89,10 +89,10 @@ class StepBuilderTest {
         val stepBuilder = StepBuilder(TEST_STEP_NAME)
 
         assertThrows<IllegalArgumentException> {
-            stepBuilder.wait(0)
+            stepBuilder.wait(0.seconds)
         }
         assertThrows<IllegalArgumentException> {
-            stepBuilder.wait(181)
+            stepBuilder.wait(181.seconds)
         }
     }
 
@@ -160,7 +160,7 @@ class StepBuilderTest {
         val requestBuilderMock = makeRequestBuilderHappyPathMock()
         val stepBuilder = StepBuilder(TEST_STEP_NAME, requestBuilderMock)
         stepBuilder.request { }
-        stepBuilder.wait(30)
+        stepBuilder.wait(30.seconds)
 
         val exception =
             assertThrows<IllegalStateException> {

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2EMultiStepApiTest.kt
@@ -93,7 +93,7 @@ class E2EMultiStepApiTest {
                     }
                 }
                 step("Wait for 5 seconds") {
-                    wait(5)
+                    wait(15.seconds)
                 }
             }
         }


### PR DESCRIPTION
Problem: Wait API step can accept both seconds and minutes, but when using Int unit users need to enter only values in seconds, which is not the best developer experience.

Solution: Replace Int with Duration unit in wait step to give users a possibility to provide values in both seconds and minutes