### PR TITLE
Convert to the next unit when the date pattern value is bigger than 1M

### DIFF
--- a/src/main/kotlin/com/personio/synthetics/config/Variable.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/Variable.kt
@@ -94,7 +94,7 @@ fun BrowserTest.datePatternVariable(
 ) = apply {
     val (scaledValue, unit) =
         checkNotNull(getScaledDate(duration)) {
-            "The passed duration should be less than 10_000_000 days for the date pattern variable $name."
+            "The passed duration should be less than 1_000_000 days for the date pattern variable $name."
         }
     addLocalVariable(name, "$prefix{{ date($scaledValue$unit, $format) }}$suffix")
 }
@@ -164,7 +164,7 @@ private fun BrowserTest.addLocalVariable(
 private fun getScaledDate(value: Duration): Pair<Long, String>? =
     value.getScaledValue(
         sequenceOf(DurationUnit.MILLISECONDS, DurationUnit.SECONDS, DurationUnit.MINUTES, DurationUnit.HOURS, DurationUnit.DAYS),
-        10_000_000,
+        1_000_000,
     )
 
 private fun getScaledTimestamp(value: Duration): Pair<Long, String>? =

--- a/src/test/kotlin/com/personio/synthetics/config/VariableTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/config/VariableTest.kt
@@ -292,6 +292,46 @@ class VariableTest {
     }
 
     @Test
+    fun `datePatternVariable output is more than 1M seconds so it returns minutes`() {
+        val variableName = "VARIABLE1"
+        val dateValue = 45.days
+        val dateFormat = "YYYY-MM-DD"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ date(${dateValue.inWholeMinutes}m, $dateFormat) }}")
+
+        browserTest.datePatternVariable(
+            name = variableName,
+            duration = dateValue,
+            format = dateFormat,
+        )
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
+    fun `datePatternVariable output is more than 1M minutes so it returns hours`() {
+        val variableName = "VARIABLE1"
+        val dateValue = 700.days
+        val dateFormat = "YYYY-MM-DD"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ date(${dateValue.inWholeHours}h, $dateFormat) }}")
+
+        browserTest.datePatternVariable(
+            name = variableName,
+            duration = dateValue,
+            format = dateFormat,
+        )
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
     fun `datePatternVariable allows a value to be appended before the pattern`() {
         val variableName = "VARIABLE1"
         val dateValue = 5.minutes
@@ -336,9 +376,9 @@ class VariableTest {
     }
 
     @Test
-    fun `datePatternVariable uses the next higher unit if the value is greater than or equal to 10_000_000`() {
+    fun `datePatternVariable uses the next higher unit if the value is greater than or equal to 1_000_000`() {
         val variableName = "VARIABLE1"
-        val dateValue = 10_000_000.minutes
+        val dateValue = 1_000_000.minutes
         val dateFormat = "YYYY-MM-DD"
 
         val expectedResult =
@@ -356,9 +396,29 @@ class VariableTest {
     }
 
     @Test
-    fun `datePatternVariable allows passing the duration less than 10_000_000 days`() {
+    fun `datePatternVariable does not use the next higher unit if the value is lower than 1_000_000`() {
         val variableName = "VARIABLE1"
-        val dateValue = 9_999_999.days
+        val dateValue = 999_999.minutes
+        val dateFormat = "YYYY-MM-DD"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ date(${dateValue.inWholeMinutes}m, $dateFormat) }}")
+
+        browserTest.datePatternVariable(
+            name = variableName,
+            duration = dateValue,
+            format = dateFormat,
+        )
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
+    fun `datePatternVariable allows passing the duration less than 1_000_000 days`() {
+        val variableName = "VARIABLE1"
+        val dateValue = 999_999.days
         val dateFormat = "YYYY-MM-DD"
 
         val expectedResult =


### PR DESCRIPTION
DD backend accepts `DatePattern` values up to 10M, but DD UI does not render properly when the value of the `DatePattern` is high than 20 bits (~1M).

For example, a `DattePattern` value of `15.days` gets converted by this library into the smaller unit (ms-> s-> m-> h-> d) whose value will be < 10M, which, in this particular case will be `1296000s` will be accepted by the backend but it will cause DD UI to not show neither the steps nor the variables.  

This PR changes the behavior to jump to the next unit if the value is > 1M instead of > 10M. Also adds unit tests for this behavior.