### PR TITLE
Convert to the next unit when the date pattern value is bigger than 1M

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### New features & improvements
 
 ### Bug fixes
+- Convert to the next unit when the date pattern value is bigger than 1M ([#274](https://github.com/personio/datadog-synthetic-test-support/pull/273))
 
 ### Dependencies
 - Update commons-text dependency from 1.12.0 to 1.13.0 ([#270](https://github.com/personio/datadog-synthetic-test-support/pull/270))

--- a/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
+++ b/src/main/kotlin/com/personio/synthetics/builder/SyntheticTestBuilder.kt
@@ -314,7 +314,7 @@ abstract class SyntheticTestBuilder(
     ) {
         val (scaledValue, unit) =
             checkNotNull(getScaledDate(duration)) {
-                "The passed duration should be less than 10_000_000 days for the date pattern variable $name."
+                "The passed duration should be between -1_000_000 and 1_000_000 days for the date pattern variable $name."
             }
         addLocalVariable(name, "$prefix{{ date($scaledValue$unit, $format) }}$suffix")
     }
@@ -335,7 +335,7 @@ abstract class SyntheticTestBuilder(
     ) {
         val (scaledValue, unit) =
             checkNotNull(getScaledTimestamp(duration)) {
-                "The passed duration should be less than 1_000_000_000 seconds for the timestamp pattern variable $name."
+                "The passed duration should be between -999_999_999 and 999_999_999 seconds for the timestamp pattern variable $name."
             }
         addLocalVariable(name, "$prefix{{ timestamp($scaledValue, $unit) }}$suffix")
     }
@@ -375,13 +375,13 @@ abstract class SyntheticTestBuilder(
     private fun getScaledDate(value: Duration): Pair<Long, String>? =
         value.getScaledValue(
             sequenceOf(DurationUnit.MILLISECONDS, DurationUnit.SECONDS, DurationUnit.MINUTES, DurationUnit.HOURS, DurationUnit.DAYS),
-            10_000_000,
+            1_000_000,
         )
 
     private fun getScaledTimestamp(value: Duration): Pair<Long, String>? =
         value.getScaledValue(
             sequenceOf(DurationUnit.MILLISECONDS, DurationUnit.SECONDS),
-            1_000_000_000,
+            999_999_999,
         )
 
     private fun Duration.getScaledValue(
@@ -390,7 +390,7 @@ abstract class SyntheticTestBuilder(
     ): Pair<Long, String>? =
         sequence
             .map { unit -> this.toLong(unit) to unit.toDatadogDurationUnit() }
-            .firstOrNull { (scaled, _) -> scaled.absoluteValue < limit }
+            .firstOrNull { (scaled, _) -> scaled.absoluteValue <= limit }
 
     private fun DurationUnit.toDatadogDurationUnit(): String {
         return when (this) {

--- a/src/main/kotlin/com/personio/synthetics/config/Variable.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/Variable.kt
@@ -94,7 +94,7 @@ fun BrowserTest.datePatternVariable(
 ) = apply {
     val (scaledValue, unit) =
         checkNotNull(getScaledDate(duration)) {
-            "The passed duration should be less than 10_000_000 days for the date pattern variable $name."
+            "The passed duration should be between -1_000_000 and 1_000_000 days for the date pattern variable $name."
         }
     addLocalVariable(name, "$prefix{{ date($scaledValue$unit, $format) }}$suffix")
 }
@@ -116,7 +116,7 @@ fun BrowserTest.timestampPatternVariable(
 ) = apply {
     val (scaledValue, unit) =
         checkNotNull(getScaledTimestamp(duration)) {
-            "The passed duration should be less than 1_000_000_000 seconds for the timestamp pattern variable $name."
+            "The passed duration should be between -999_999_999 and 999_999_999 seconds for the timestamp pattern variable $name."
         }
     addLocalVariable(name, "$prefix{{ timestamp($scaledValue, $unit) }}$suffix")
 }
@@ -164,13 +164,13 @@ private fun BrowserTest.addLocalVariable(
 private fun getScaledDate(value: Duration): Pair<Long, String>? =
     value.getScaledValue(
         sequenceOf(DurationUnit.MILLISECONDS, DurationUnit.SECONDS, DurationUnit.MINUTES, DurationUnit.HOURS, DurationUnit.DAYS),
-        10_000_000,
+        1_000_000,
     )
 
 private fun getScaledTimestamp(value: Duration): Pair<Long, String>? =
     value.getScaledValue(
         sequenceOf(DurationUnit.MILLISECONDS, DurationUnit.SECONDS),
-        1_000_000_000,
+        999_999_999,
     )
 
 private fun Duration.getScaledValue(
@@ -179,7 +179,7 @@ private fun Duration.getScaledValue(
 ): Pair<Long, String>? =
     sequence
         .map { unit -> this.toLong(unit) to unit.toDatadogDurationUnit() }
-        .firstOrNull { (scaled, _) -> scaled.absoluteValue < limit }
+        .firstOrNull { (scaled, _) -> scaled.absoluteValue <= limit }
 
 private fun DurationUnit.toDatadogDurationUnit(): String {
     return when (this) {

--- a/src/test/kotlin/com/personio/synthetics/config/VariableTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/config/VariableTest.kt
@@ -292,6 +292,46 @@ class VariableTest {
     }
 
     @Test
+    fun `datePatternVariable output is more than 1M seconds so it returns minutes`() {
+        val variableName = "VARIABLE1"
+        val dateValue = 45.days
+        val dateFormat = "YYYY-MM-DD"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ date(${dateValue.inWholeMinutes}m, $dateFormat) }}")
+
+        browserTest.datePatternVariable(
+            name = variableName,
+            duration = dateValue,
+            format = dateFormat,
+        )
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
+    fun `datePatternVariable output is more than 1M minutes so it returns hours`() {
+        val variableName = "VARIABLE1"
+        val dateValue = 700.days
+        val dateFormat = "YYYY-MM-DD"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ date(${dateValue.inWholeHours}h, $dateFormat) }}")
+
+        browserTest.datePatternVariable(
+            name = variableName,
+            duration = dateValue,
+            format = dateFormat,
+        )
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
     fun `datePatternVariable allows a value to be appended before the pattern`() {
         val variableName = "VARIABLE1"
         val dateValue = 5.minutes
@@ -336,9 +376,9 @@ class VariableTest {
     }
 
     @Test
-    fun `datePatternVariable uses the next higher unit if the value is greater than or equal to 10_000_000`() {
+    fun `datePatternVariable uses the next higher unit if the value is greater than 1_000_000`() {
         val variableName = "VARIABLE1"
-        val dateValue = 10_000_000.minutes
+        val dateValue = 1_000_001.minutes
         val dateFormat = "YYYY-MM-DD"
 
         val expectedResult =
@@ -356,9 +396,29 @@ class VariableTest {
     }
 
     @Test
-    fun `datePatternVariable allows passing the duration less than 10_000_000 days`() {
+    fun `datePatternVariable does not use the next higher unit if the value is lower than 1_000_001`() {
         val variableName = "VARIABLE1"
-        val dateValue = 9_999_999.days
+        val dateValue = 1_000_000.minutes
+        val dateFormat = "YYYY-MM-DD"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ date(${dateValue.inWholeMinutes}m, $dateFormat) }}")
+
+        browserTest.datePatternVariable(
+            name = variableName,
+            duration = dateValue,
+            format = dateFormat,
+        )
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
+    fun `datePatternVariable allows passing the duration less than or equal to 1_000_000 days`() {
+        val variableName = "VARIABLE1"
+        val dateValue = 1_000_000.days
         val dateFormat = "YYYY-MM-DD"
 
         val expectedResult =
@@ -416,11 +476,11 @@ class VariableTest {
     }
 
     @Test
-    fun `datePatternVariable throws an exception if the duration is greater than or equal to 10_000_000 days`() {
+    fun `datePatternVariable throws an exception if the duration is greater than 1_000_000 days`() {
         assertThrows<IllegalStateException> {
             browserTest.datePatternVariable(
                 name = "VARIABLE1",
-                duration = 10_000_000.days,
+                duration = 1_000_001.days,
                 format = "YYYY-MM-DD",
             )
         }


### PR DESCRIPTION
Subject: Merge [#273](https://github.com/personio/datadog-synthetic-test-support/pull/273) PR into master

Problem: DD backend accepts DatePattern values up to 10M, but DD UI does not render properly when the value of the DatePattern is high than 20 bits (~1M).

For example, a DatePattern value of 15.days gets converted by this library into the smaller unit (ms-> s-> m-> h-> d) whose value will be < 10M, which, in this particular case will be 1296000s will be accepted by the backend but it will cause DD UI to not show neither the steps nor the variables.

Solution: This PR changes the behavior to jump to the next unit if the value is >= 1M instead of > 10M. Also adds unit tests for this behavior.