### PR TITLE
Remove deprecation warning due to the SyntheticTestBuilder project pu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Bug fixes
 - Convert to the next unit when the date pattern value is bigger than 1M ([#274](https://github.com/personio/datadog-synthetic-test-support/pull/273))
+- Remove deprecation warning due to the SyntheticTestBuilder put on hold ([#276](https://github.com/personio/datadog-synthetic-test-support/pull/276))
 
 ### Dependencies
 - Update commons-text dependency from 1.12.0 to 1.13.0 ([#270](https://github.com/personio/datadog-synthetic-test-support/pull/270))

--- a/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
+++ b/src/main/kotlin/com/personio/synthetics/client/BrowserTest.kt
@@ -15,13 +15,9 @@ import com.personio.synthetics.model.config.SyntheticsDeviceID
 /**
  * Creates a synthetic browser test with the added configurations (if any) and steps in Datadog
  * The default configurations for the tests are loaded from the configuration file in resources.
- *
- * Deprecation notice: In future releases this method will be replaced by one that
- * uses SyntheticTestBuilder or similar.
  * @param name Name of the test
  * @param steps Calls the added steps and configuration functions of the test
  */
-@Deprecated(message = "This function will have its package and signature changed in 3.x.x")
 inline fun syntheticBrowserTest(
     name: String,
     steps: BrowserTest.() -> Unit,
@@ -49,11 +45,7 @@ fun getCredentialsProvider(): CredentialsProvider {
 
 /**
  * Synthetic browser test client for the API calls with the Datadog.
- *
- * Deprecation notice: In future releases this class will be replaced by
- * SyntheticTestBuilder (or similar).
  */
-@Deprecated(message = "Planned for removal in 3.x.x")
 class BrowserTest(
     testName: String,
     private val syntheticsApiClient: SyntheticsApiClient,
@@ -73,7 +65,6 @@ class BrowserTest(
      * @return SyntheticsBrowserTest object
      */
     @PublishedApi
-    @Deprecated(message = "Planned for removal in 3.x.x")
     internal fun createBrowserTest(): SyntheticsBrowserTest {
         val testId = getTestId()
         return if (testId != null) {

--- a/src/main/kotlin/com/personio/synthetics/config/BrowserTestConfig.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/BrowserTestConfig.kt
@@ -1,11 +1,5 @@
 package com.personio.synthetics.config
 
-/**
- * This code will be deprecated in the future releases as it is a duplicate of SyntheticTestBuilder.
- * Most functions are already available in SyntheticTestBuilder.
- * @see com.personio.synthetics.builder.SyntheticTestBuilder
- */
-
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsScheduling
 import com.datadog.api.client.v1.model.SyntheticsTestOptionsSchedulingTimeframe
 import com.datadog.api.client.v1.model.SyntheticsTestRequest


### PR DESCRIPTION
Problem: Currently the SyntheticTestBuilder is not completed, thus there is no alternative to the current approach for creating browser tests. This creates confusion since warnings are displayed when running tests, but there is no way to get rid of them.
Soltuion: Remove deprecation warning until SyntheticTestBuilder as an alternative solution is ready to use.