### PR TITLE
Add uuidVariable extension to create a local variable with an UUID

### DIFF
--- a/src/main/kotlin/com/personio/synthetics/config/Variable.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/Variable.kt
@@ -122,6 +122,22 @@ fun BrowserTest.timestampPatternVariable(
 }
 
 /**
+ * Create a local variable with an uuid
+ * The value generated will be a version 4 universally unique identifier.
+ * @param name Name of the variable. The name would be converted to upper case letters
+ * @param prefix String to be appended before the pattern
+ * @param suffix String to be appended after the pattern
+ * @return SyntheticsBrowserTest object with this created variable
+ */
+fun BrowserTest.uuidVariable(
+    name: String,
+    prefix: String = "",
+    suffix: String = "",
+) = apply {
+    addLocalVariable(name, "$prefix{{ uuid }}$suffix")
+}
+
+/**
  * Uses the global variable in the test
  * @param name Name of the existing global variable. The name would be converted to upper case letters
  * @return BrowserTest object with this added global variable

--- a/src/test/kotlin/com/personio/synthetics/config/VariableTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/config/VariableTest.kt
@@ -681,6 +681,50 @@ class VariableTest {
     }
 
     @Test
+    fun `uuidVariable adds a variable with generated UUID`() {
+        val variableName = "TEST_VARIABLE"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ uuid }}")
+
+        browserTest.uuidVariable(variableName)
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
+    fun `uuidVariable allows a value to be appended before the pattern`() {
+        val variableName = "TEST_VARIABLE"
+        val prefix = "prefix"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("$prefix{{ uuid }}")
+
+        browserTest.uuidVariable(name = variableName, prefix = prefix)
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
+    fun `uuidVariable allows a value to be appended after the pattern`() {
+        val variableName = "TEST_VARIABLE"
+        val suffix = "suffix"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ uuid }}$suffix")
+
+        browserTest.uuidVariable(name = variableName, suffix = suffix)
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
     fun `fromVariable function returns the variable formatted according to datadog standards`() {
         val variableName = "TEST_VAR"
         val expectedVariableFormat = "{{ $variableName }}"


### PR DESCRIPTION
The PR adds a new `BrowserTest` extension named `uuidVariable`. The function adds a local variable with value of a generated version 4 UUID.