### PR TITLE
fix: navigateStep should not prepend the domain

### DIFF
--- a/src/main/kotlin/com/personio/synthetics/step/ui/ActionsStep.kt
+++ b/src/main/kotlin/com/personio/synthetics/step/ui/ActionsStep.kt
@@ -59,7 +59,7 @@ fun BrowserTest.clickStep(
  * Adds a new navigation step for following a link to the synthetic browser test
  * @param stepName Name of the step
  * @param url The navigation url. You can pass url like the following
- * - only the location (eg: /test/page) for appending to the base url of the test
+ * - only the location (eg: /test/page) for staying on the same domain
  * - pass full url including http(s)://
  * - global or local variable. For using those, use the function "fromVariable(variableName)" in the parameter
  *   for example /test/page/${fromVariable("TEST")}
@@ -72,15 +72,6 @@ fun BrowserTest.navigateStep(
     f: (SyntheticsStep.() -> Unit)? = null,
 ) = addStep(stepName) {
     type = SyntheticsStepType.GO_TO_URL
-    val target =
-        if (url.isDatadogVariable()) {
-            url
-        } else {
-            runCatching { URL(url) }
-                .recover { URL(config.request.url + url) }
-                .getOrThrow()
-                .toString()
-        }
-    params = ActionsParams(value = target)
+    params = ActionsParams(value = url)
     if (f != null) f()
 }

--- a/src/test/kotlin/com/personio/synthetics/step/ui/ActionsStepTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/step/ui/ActionsStepTest.kt
@@ -140,7 +140,6 @@ internal class ActionsStepTest {
     fun `navigateStep appends the passed navigationUrl location to the base url of the test`() {
         val baseUrl = "https://synthetic-test.personio.de"
         val url = "/test"
-        val expectedUrl = baseUrl + url
 
         browserTest
             .baseUrl(URL(baseUrl))
@@ -149,7 +148,7 @@ internal class ActionsStepTest {
                 url = url,
             )
 
-        assertEquals(expectedUrl, (browserTest.steps?.get(0)?.params as ActionsParams).value)
+        assertEquals(url, (browserTest.steps?.get(0)?.params as ActionsParams).value)
     }
 
     @Test


### PR DESCRIPTION
There's no need to prepend navigation with the fully qualified domain name as DataDog understands relative paths.
In fact a reason to not append is so that DataDog remains on the same domain if the webpage decides to redirect for any reason. 