### PR TITLE
Add UUID pattern variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Breaking changes
 
 ### New features & improvements
+- Add UUID pattern variable ([#284](https://github.com/personio/datadog-synthetic-test-support/pull/284))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/config/Variable.kt
+++ b/src/main/kotlin/com/personio/synthetics/config/Variable.kt
@@ -101,7 +101,7 @@ fun BrowserTest.datePatternVariable(
 
 /**
  * Creates a local variable with the timestamp pattern
- * The value of the variable will be a generated timestamp in one of the accepted formats with a value corresponding to the timestamp the test is initiated at +/- n unit.
+ * The value of the variable will be a generated timestamp in one of the accepted formats with a value corresponding to the timestamp the test is initiated at +/- n unit
  * @param name Name of the variable. The name would be converted to upper case letters
  * @param duration The duration (+ or -) to be added to or subtracted from the time by which the test is run to generate the date
  * @param prefix String to be appended before the pattern
@@ -119,6 +119,22 @@ fun BrowserTest.timestampPatternVariable(
             "The passed duration should be between -999_999_999 and 999_999_999 seconds for the timestamp pattern variable $name."
         }
     addLocalVariable(name, "$prefix{{ timestamp($scaledValue, $unit) }}$suffix")
+}
+
+/**
+ * Create a local variable with the UUID pattern
+ * The value generated will be a universally unique identifier version 4
+ * @param name Name of the variable. The name would be converted to upper case letters
+ * @param prefix String to be appended before the pattern
+ * @param suffix String to be appended after the pattern
+ * @return SyntheticsBrowserTest object with this created variable
+ */
+fun BrowserTest.uuidPatternVariable(
+    name: String,
+    prefix: String = "",
+    suffix: String = "",
+) = apply {
+    addLocalVariable(name, "$prefix{{ uuid }}$suffix")
 }
 
 /**

--- a/src/test/kotlin/com/personio/synthetics/config/VariableTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/config/VariableTest.kt
@@ -681,6 +681,50 @@ class VariableTest {
     }
 
     @Test
+    fun `uuidPatternVariable adds a variable with generated UUID`() {
+        val variableName = "TEST_VARIABLE"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ uuid }}")
+
+        browserTest.uuidPatternVariable(variableName)
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
+    fun `uuidPatternVariable allows a value to be appended before the pattern`() {
+        val variableName = "TEST_VARIABLE"
+        val prefix = "prefix"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("$prefix{{ uuid }}")
+
+        browserTest.uuidPatternVariable(name = variableName, prefix = prefix)
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
+    fun `uuidPatternVariable allows a value to be appended after the pattern`() {
+        val variableName = "TEST_VARIABLE"
+        val suffix = "suffix"
+
+        val expectedResult =
+            syntheticBrowserVariable()
+                .name(variableName)
+                .pattern("{{ uuid }}$suffix")
+
+        browserTest.uuidPatternVariable(name = variableName, suffix = suffix)
+
+        assertEquals(expectedResult, browserTest.config?.variables?.get(0))
+    }
+
+    @Test
     fun `fromVariable function returns the variable formatted according to datadog standards`() {
         val variableName = "TEST_VAR"
         val expectedVariableFormat = "{{ $variableName }}"

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2ETest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2ETest.kt
@@ -25,6 +25,7 @@ import com.personio.synthetics.config.testFrequency
 import com.personio.synthetics.config.textVariable
 import com.personio.synthetics.config.timestampPatternVariable
 import com.personio.synthetics.config.useGlobalVariable
+import com.personio.synthetics.config.uuidPatternVariable
 import com.personio.synthetics.model.actions.Key
 import com.personio.synthetics.model.actions.Modifier
 import com.personio.synthetics.model.assertion.FileNameCheckType
@@ -113,6 +114,9 @@ class E2ETest {
             timestampPatternVariable(
                 name = "TIMESTAMP_PATTERN",
                 duration = 10.seconds,
+            )
+            uuidPatternVariable(
+                name = "UUID_PATTERN",
             )
             inputTextStep(
                 stepName = "Enter username",


### PR DESCRIPTION
Subject: Add UUID pattern variable
Problem: Datadog UI allows users to create a UUID pattern variable, which is missing in the library.
Solution: Add a possibility to create a UUID pattern variable to the library