### PR TITLE
Remove url checks in navigate step to not prepend domain when path is used instead of url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### New features & improvements
 - Add UUID pattern variable ([#284](https://github.com/personio/datadog-synthetic-test-support/pull/284))
+- Remove url checks in navigate step to not prepend domain when path is used instead of url ([#285](https://github.com/personio/datadog-synthetic-test-support/pull/285))
 
 ### Bug fixes
 

--- a/src/main/kotlin/com/personio/synthetics/step/ui/ActionsStep.kt
+++ b/src/main/kotlin/com/personio/synthetics/step/ui/ActionsStep.kt
@@ -3,11 +3,9 @@ package com.personio.synthetics.step.ui
 import com.datadog.api.client.v1.model.SyntheticsStep
 import com.datadog.api.client.v1.model.SyntheticsStepType
 import com.personio.synthetics.client.BrowserTest
-import com.personio.synthetics.config.isDatadogVariable
 import com.personio.synthetics.model.actions.ActionsParams
 import com.personio.synthetics.step.addStep
 import com.personio.synthetics.step.ui.model.TargetElement
-import java.net.URL
 
 private const val DEFAULT_TEXT_DELAY: Long = 25 // in milliseconds
 
@@ -59,7 +57,7 @@ fun BrowserTest.clickStep(
  * Adds a new navigation step for following a link to the synthetic browser test
  * @param stepName Name of the step
  * @param url The navigation url. You can pass url like the following
- * - only the location (eg: /test/page) for appending to the base url of the test
+ * - only the location (eg: /test/page) for staying on the same domain
  * - pass full url including http(s)://
  * - global or local variable. For using those, use the function "fromVariable(variableName)" in the parameter
  *   for example /test/page/${fromVariable("TEST")}
@@ -72,15 +70,6 @@ fun BrowserTest.navigateStep(
     f: (SyntheticsStep.() -> Unit)? = null,
 ) = addStep(stepName) {
     type = SyntheticsStepType.GO_TO_URL
-    val target =
-        if (url.isDatadogVariable()) {
-            url
-        } else {
-            runCatching { URL(url) }
-                .recover { URL(config.request.url + url) }
-                .getOrThrow()
-                .toString()
-        }
-    params = ActionsParams(value = target)
+    params = ActionsParams(value = url)
     if (f != null) f()
 }

--- a/src/test/kotlin/com/personio/synthetics/e2e/E2ETest.kt
+++ b/src/test/kotlin/com/personio/synthetics/e2e/E2ETest.kt
@@ -177,7 +177,7 @@ class E2ETest {
             )
             navigateStep(
                 stepName = "Navigate to test page by URL",
-                url = "https://synthetic-test.personio.de/test",
+                url = "/test",
             )
             customJavascriptAssertion(
                 stepName = "Check custom JS",

--- a/src/test/kotlin/com/personio/synthetics/step/ui/ActionsStepTest.kt
+++ b/src/test/kotlin/com/personio/synthetics/step/ui/ActionsStepTest.kt
@@ -140,7 +140,6 @@ internal class ActionsStepTest {
     fun `navigateStep appends the passed navigationUrl location to the base url of the test`() {
         val baseUrl = "https://synthetic-test.personio.de"
         val url = "/test"
-        val expectedUrl = baseUrl + url
 
         browserTest
             .baseUrl(URL(baseUrl))
@@ -149,7 +148,7 @@ internal class ActionsStepTest {
                 url = url,
             )
 
-        assertEquals(expectedUrl, (browserTest.steps?.get(0)?.params as ActionsParams).value)
+        assertEquals(url, (browserTest.steps?.get(0)?.params as ActionsParams).value)
     }
 
     @Test


### PR DESCRIPTION
Problem: Currently the checks in navigation steps doesn't allow to properly redirect url with prepended domain.
Solution: Remove the url checks to allow proper url redirection to the needed domain

Contributor's PR: #283 